### PR TITLE
Fixing segfaults and other issues

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -662,19 +662,23 @@ def register():
     bpy.app.handlers.load_post.append(onLoadFile)
     bpy.app.handlers.undo_post.append(onUndo)
 
-    # Kill ArtNet Thread at exit
-    atexit.register(DMX_ArtNet.disable)
+    # since 2.91.0 unregister is called also on Blender exit
+    if (2, 91, 0) > bpy.app.version:
+        atexit.register(DMX_ArtNet.disable)
 
 def unregister():
     # Stop ArtNet
     DMX_ArtNet.disable()
 
-    # Unregister Base Classes
-    for cls in DMX.classes_base:
-        bpy.utils.unregister_class(cls)
+    try:
+        # Unregister Base Classes
+        for cls in DMX.classes_base:
+            bpy.utils.unregister_class(cls)
 
-    # Unregister addon main class
-    bpy.utils.unregister_class(DMX)
+        # Unregister addon main class
+        bpy.utils.unregister_class(DMX)
+    except Exception as e:
+        print(e)
 
     # Append handlers
     bpy.app.handlers.load_post.clear()

--- a/__init__.py
+++ b/__init__.py
@@ -663,7 +663,7 @@ def register():
     bpy.app.handlers.undo_post.append(onUndo)
 
     # since 2.91.0 unregister is called also on Blender exit
-    if (2, 91, 0) > bpy.app.version:
+    if bpy.app.version <= (2, 91, 0):
         atexit.register(DMX_ArtNet.disable)
 
 def unregister():

--- a/artnet.py
+++ b/artnet.py
@@ -58,14 +58,17 @@ class DMX_ArtNet(threading.Thread):
         self._socket = socket(AF_INET, SOCK_DGRAM)
         self._socket.bind((ip_addr, ARTNET_PORT))
         self._socket.settimeout(30)
-        self._stop = False
+        self._stopped = False
 
     def stop(self):
-        self._socket.shutdown(SHUT_RDWR)
-        self._stop = True           
+        try:
+            self._socket.shutdown(SHUT_RDWR)
+        except Exception as e:
+            print(e)
+        self._stopped = True
 
     def run(self):
-        while not self._stop:
+        while not self._stopped:
             try:
                 data, _ = self._socket.recvfrom(1024)
                 packet = ArtnetPacket.build(data)
@@ -73,11 +76,10 @@ class DMX_ArtNet(threading.Thread):
 
                 if (packet.universe >= len(self._dmx.universes)):
                     continue
-                if (self._dmx.universes[packet.universe].input != 'ARTNET'):
+                if (not self._dmx.universes[packet.universe] or self._dmx.universes[packet.universe].input != 'ARTNET'):
                     continue
-
-                if (DMX_Data.set_universe(packet.universe, bytearray(packet.data))):
-                    self._dmx.render()
+                
+                DMX_Data.set_universe(packet.universe, bytearray(packet.data))
                 
                 #print(packet)
             except Exception as e:
@@ -87,6 +89,11 @@ class DMX_ArtNet(threading.Thread):
         self._dmx.artnet_status = 'socket_close'
         self._socket.close()
         self._dmx.artnet_status = 'offline'
+    
+    @staticmethod
+    def run_render():
+        bpy.context.scene.dmx.render()
+        return (1.0/60.0)
     
     @staticmethod
     def enable():
@@ -101,25 +108,30 @@ class DMX_ArtNet(threading.Thread):
 
         DMX_ArtNet._thread = DMX_ArtNet(dmx.artnet_ipaddr)
         DMX_ArtNet._thread.start()
+        
+        bpy.app.timers.register(DMX_ArtNet.run_render)
 
         dmx.artnet_status = 'listen'
         print('ArtNet client started.')
     
     @staticmethod
     def disable():
+        if (bpy.app.timers.is_registered(DMX_ArtNet.run_render)):
+            bpy.app.timers.unregister(DMX_ArtNet.run_render)
+            
         dmx = bpy.context.scene.dmx
 
-        if (not DMX_ArtNet._thread):
+        if (DMX_ArtNet._thread):
+            print('Stopping ArtNet client...', end='', flush=True)
+            dmx.artnet_status = 'stop'
+            DMX_ArtNet._thread.stop()
+            DMX_ArtNet._thread.join()
+            DMX_ArtNet._thread = None
             dmx.artnet_status = 'offline'
-            return
-            
-        print('Stopping ArtNet client...', end='', flush=True)
-        dmx.artnet_status = 'stop'
-        DMX_ArtNet._thread.stop()
-        DMX_ArtNet._thread = None
-        dmx.artnet_status = 'offline'
-        print('DONE')
-    
+            print('DONE')
+        elif:
+            dmx.artnet_status = 'offline'
+                
     @staticmethod
     def status():
         return [

--- a/artnet.py
+++ b/artnet.py
@@ -76,7 +76,9 @@ class DMX_ArtNet(threading.Thread):
 
                 if (packet.universe >= len(self._dmx.universes)):
                     continue
-                if (not self._dmx.universes[packet.universe] or self._dmx.universes[packet.universe].input != 'ARTNET'):
+                if (not self._dmx.universes[packet.universe]):
+                    continue
+                if (self._dmx.universes[packet.universe].input != 'ARTNET'):
                     continue
                 
                 DMX_Data.set_universe(packet.universe, bytearray(packet.data))

--- a/artnet.py
+++ b/artnet.py
@@ -129,7 +129,7 @@ class DMX_ArtNet(threading.Thread):
             DMX_ArtNet._thread = None
             dmx.artnet_status = 'offline'
             print('DONE')
-        elif:
+        elif(dmx):
             dmx.artnet_status = 'offline'
                 
     @staticmethod

--- a/data.py
+++ b/data.py
@@ -37,7 +37,7 @@ class DMX_Data():
     @staticmethod
     def set(universe, addr, val):
         if (universe >= len(DMX_Data._universes)): return
-        if (bpy.context.scene.dmx.universes[universe].input != 'BLENDERDMX'): return
+        if (not bpy.context.scene.dmx.universes[universe] or bpy.context.scene.dmx.universes[universe].input != 'BLENDERDMX'): return
         DMX_Data._universes[universe-1][addr-1] = val
 
     @staticmethod

--- a/data.py
+++ b/data.py
@@ -37,7 +37,8 @@ class DMX_Data():
     @staticmethod
     def set(universe, addr, val):
         if (universe >= len(DMX_Data._universes)): return
-        if (not bpy.context.scene.dmx.universes[universe] or bpy.context.scene.dmx.universes[universe].input != 'BLENDERDMX'): return
+        if (not bpy.context.scene.dmx.universes[universe]): return
+        if (bpy.context.scene.dmx.universes[universe].input != 'BLENDERDMX'): return
         DMX_Data._universes[universe-1][addr-1] = val
 
     @staticmethod


### PR DESCRIPTION
Hi!

I wanted to share my branch, perhaps some or all of the code can be merged.
This was basically my attempt to fix all errors: segmentation faults and other errors that came up in Blender console.
1. First I moved the `dmx.render` method out of the thread and into a Timer (see lines [95](https://github.com/hugoaboud/blenderDMX/compare/main...kasparsj:blenderDMX:kasparsj-segfault-1?expand=1#diff-55facb600782a28602668c1d337b786089197b5ef483116337ad153b5f5dce75R93), [111](https://github.com/hugoaboud/blenderDMX/compare/main...kasparsj:blenderDMX:kasparsj-segfault-1?expand=1#diff-55facb600782a28602668c1d337b786089197b5ef483116337ad153b5f5dce75R112)), this made huge difference - no segfaults while running the scene
2. I was running Blender 3.2.1 and when I quit running a DMX scene, it would always crash. That was fixed by not running the `atexit` [handler](https://github.com/hugoaboud/blenderDMX/compare/main...kasparsj:blenderDMX:kasparsj-segfault-1?expand=1#diff-8e2c1f727276d30ced72fa67cb848772a9802162bec39b42a8df5359fd063a4cR667), because since version 2.9.1 Blender automatically calls `unregister`
3. all else were small fixes, for errors that came up in the console, most of the times something was not defined and required a check before accessing, or a [try/catch block](https://github.com/hugoaboud/blenderDMX/compare/main...kasparsj:blenderDMX:kasparsj-segfault-1?expand=1#diff-8e2c1f727276d30ced72fa67cb848772a9802162bec39b42a8df5359fd063a4cR673)