### PR TITLE
Adding Zoom and ColorSub_C/M/Y GDTF attributes, Pigtail settings, catch several crash errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ fixtures/__pycache__
 panels/__pycache__
 
 assets/profiles/*
+assets/models/*/*
 !assets/profiles/BlenderDMX*

--- a/__init__.py
+++ b/__init__.py
@@ -71,6 +71,7 @@ class DMX(PropertyGroup):
                 DMX_OT_Setup_Volume_Create,
                 DMX_PT_Setup_Background,
                 DMX_PT_Setup_Volume,
+                DMX_PT_Setup_Models,
                 DMX_MT_Fixture,
                 DMX_MT_Fixture_Manufacturers,
                 DMX_MT_Fixture_Profiles,
@@ -255,6 +256,19 @@ class DMX(PropertyGroup):
         default = (0.0,0.0,0.0,1.0),
         update = onBackgroundColor
         )
+
+    # # Setup > Models > Display Pigtails
+
+    def onDisplayPigtails(self, context):
+        #self.updateDisplayPigtails()
+        #breakpoint()
+        ...
+
+    display_pigtails: BoolProperty(
+        name = "Display pigtails",
+        default = False,
+        update = onDisplayPigtails)
+
 
     # # Setup > Volume > Preview Volume
 

--- a/__init__.py
+++ b/__init__.py
@@ -28,6 +28,7 @@ from dmx.panels.dmx import *
 from dmx.panels.fixtures import *
 from dmx.panels.groups import *
 from dmx.panels.programmer import *
+from dmx.util import rgb_to_cmy
 
 from bpy.props import (BoolProperty,
                        IntProperty,
@@ -260,9 +261,7 @@ class DMX(PropertyGroup):
     # # Setup > Models > Display Pigtails
 
     def onDisplayPigtails(self, context):
-        #self.updateDisplayPigtails()
-        #breakpoint()
-        ...
+        self.updateDisplayPigtails()
 
     display_pigtails: BoolProperty(
         name = "Display pigtails",
@@ -420,29 +419,8 @@ class DMX(PropertyGroup):
 
     # # Programmer > Color
 
-    def cmy_to_rgb(self, cmy):
-        rgb=[0,0,0]
-        rgb[0] = int(255 * (1.0 - cmy[0] / 255))
-        rgb[1] = int(255 * (1.0 - cmy[1] / 255))
-        rgb[2] = int(255 * (1.0 - cmy[2] / 255))
-        return rgb
-
     def onProgrammerColor(self, context):
         
-        def rgb_to_cmy(rgb):
-            if (rgb) == [0,0,0]:
-                return [255,255,255]
-
-            c = 1 - rgb[0] / 255
-            m = 1 - rgb[1] / 255
-            y = 1 - rgb[2] / 255
-
-            min_cmy = min(c, m, y)
-            c = (c - min_cmy) / (1 - min_cmy)
-            m = (m - min_cmy) / (1 - min_cmy)
-            y = (y - min_cmy) / (1 - min_cmy)
-
-            return [int(c * 255), int(m * 255), int(y * 255)]
 
         bpy.app.handlers.depsgraph_update_post.clear()
         for fixture in self.fixtures:

--- a/__init__.py
+++ b/__init__.py
@@ -428,8 +428,6 @@ class DMX(PropertyGroup):
                 if (obj in bpy.context.selected_objects):
                     rgb=[int(255*x) for x in self.programmer_color]
                     cmy=rgb_to_cmy(rgb)
-                    print("rgb:", rgb)
-                    print("cmy:", cmy)
 
                     fixture.setDMX({
                         'ColorAdd_R':rgb[0],

--- a/__init__.py
+++ b/__init__.py
@@ -473,6 +473,17 @@ class DMX(PropertyGroup):
         self.render()
         bpy.app.handlers.depsgraph_update_post.append(onDepsgraph)
 
+    def onProgrammerZoom(self, context):
+        bpy.app.handlers.depsgraph_update_post.clear()
+        for fixture in self.fixtures:
+            for obj in fixture.collection.objects:
+                if (obj in bpy.context.selected_objects):
+                    fixture.setDMX({
+                        'Zoom':int((255/180)*self.programmer_zoom)
+                    })
+        self.render()
+        bpy.app.handlers.depsgraph_update_post.append(onDepsgraph)
+
     programmer_tilt: FloatProperty(
         name = "Programmer Tilt",
         min = -1.0,
@@ -480,6 +491,12 @@ class DMX(PropertyGroup):
         default = 0.0,
         update = onProgrammerTilt)
     
+    programmer_zoom: IntProperty(
+        name = "Programmer Zoom",
+        min = 1,
+        max = 180,
+        default = 25,
+        update = onProgrammerZoom)
     # # Programmer > Sync
 
     def syncProgrammer(self):
@@ -489,6 +506,7 @@ class DMX(PropertyGroup):
             self.programmer_color = (255,255,255,255)
             self.programmer_pan = 0
             self.programmer_tilt = 0
+            self.programmer_zoom = 25
             return
         elif (n > 1): return
         if (not bpy.context.active_object): return
@@ -496,6 +514,8 @@ class DMX(PropertyGroup):
         if (not active): return
         data = active.getProgrammerData()
         self.programmer_dimmer = data['Dimmer']/256.0
+        if ('Zoom' in data):
+            self.programmer_zoom = data['Zoom']/256.0
         if ('R' in data and 'G' in data and 'B' in data):
             self.programmer_color = (data['R'],data['G'],data['B'],255)
         if ('Pan' in data):

--- a/fixture.py
+++ b/fixture.py
@@ -236,6 +236,7 @@ class DMX_Fixture(PropertyGroup):
         data = DMX_Data.get(self.universe, self.address, len(channels))
         panTilt = [None,None]
         rgb = [None,None,None]
+        zoom = None
         for c in range(len(channels)):
             if (channels[c] == 'Dimmer'): self.updateDimmer(data[c])
             elif (channels[c] == 'R'): rgb[0] = data[c]
@@ -243,6 +244,7 @@ class DMX_Fixture(PropertyGroup):
             elif (channels[c] == 'B'): rgb[2] = data[c]
             elif (channels[c] == 'Pan'): panTilt[0] = data[c]
             elif (channels[c] == 'Tilt'): panTilt[1] = data[c]
+            elif (channels[c] == 'Zoom'): zoom = data[c]
         
         if (rgb[0] != None and rgb[1] != None and rgb[2] != None):
             self.updateRGB(rgb)
@@ -251,6 +253,8 @@ class DMX_Fixture(PropertyGroup):
 
         if (panTilt[0] != None and panTilt[1] != None):
             self.updatePanTilt(panTilt[0], panTilt[1])
+        if (zoom != None):
+            self.updateZoom(zoom)
 
     def updateDimmer(self, dimmer):
         self.emitter_material.node_tree.nodes[1].inputs[STRENGTH].default_value = 10*(dimmer/255.0)
@@ -265,6 +269,13 @@ class DMX_Fixture(PropertyGroup):
         for light in self.lights:
             light.object.data.color = rgb
         return rgb
+
+    def updateZoom(self, zoom):
+        spot_size=zoom*3.1415/180.0
+        for light in self.lights:
+            light.object.data.spot_size=spot_size
+        return zoom
+
 
     def updatePanTilt(self, pan, tilt):
         pan = (pan/127.0-1)*355*(math.pi/360)

--- a/fixture.py
+++ b/fixture.py
@@ -199,13 +199,16 @@ class DMX_Fixture(PropertyGroup):
         for obj in self.collection.objects:
             if ('Beam' in obj.name):
                 emitter = obj
-        assert emitter
+        try:
+            assert emitter
+            self.emitter_material = getEmitterMaterial(name)
+            emitter.active_material = self.emitter_material
+            emitter.material_slots[0].link = 'OBJECT'
+            emitter.material_slots[0].material = self.emitter_material
+            emitter.material_slots[0].material.shadow_method = 'NONE' # eevee
+        except Exception as e:
+            print("Emitter required", e)
 
-        self.emitter_material = getEmitterMaterial(name)
-        emitter.active_material = self.emitter_material
-        emitter.material_slots[0].link = 'OBJECT'
-        emitter.material_slots[0].material = self.emitter_material
-        emitter.material_slots[0].material.shadow_method = 'NONE' # eevee
 
         # Link collection to DMX collection
         bpy.context.scene.dmx.collection.children.link(self.collection)

--- a/fixture.py
+++ b/fixture.py
@@ -279,7 +279,6 @@ class DMX_Fixture(PropertyGroup):
 
 
     def updateCMY(self, cmy):
-        print("update cmy: ", cmy)
         rgb=[0,0,0]
         rgb=cmy_to_rgb(cmy)
         rgb = [c/255.0-(1-gel) for (c, gel) in zip(rgb, self.gel_color[:3])]

--- a/fixture.py
+++ b/fixture.py
@@ -16,6 +16,7 @@ from dmx.param import DMX_Param, DMX_Model_Param
 
 from dmx.gdtf import DMX_GDTF
 from dmx.data import DMX_Data
+from dmx.util import cmy_to_rgb
 
 from bpy.props import (IntProperty,
                        FloatProperty,
@@ -239,7 +240,6 @@ class DMX_Fixture(PropertyGroup):
         rgb = [None,None,None]
         cmy = [None,None,None]
         zoom = None
-        #breakpoint()
         for c in range(len(channels)):
             if (channels[c] == 'Dimmer'): self.updateDimmer(data[c])
             elif (channels[c] == 'ColorAdd_R'): rgb[0] = data[c]
@@ -281,13 +281,6 @@ class DMX_Fixture(PropertyGroup):
     def updateCMY(self, cmy):
         print("update cmy: ", cmy)
         rgb=[0,0,0]
-
-        def cmy_to_rgb(cmy):
-            rgb[0] = int(255 * (1.0 - cmy[0] / 255))
-            rgb[1] = int(255 * (1.0 - cmy[1] / 255))
-            rgb[2] = int(255 * (1.0 - cmy[2] / 255))
-            return rgb
-
         rgb=cmy_to_rgb(cmy)
         rgb = [c/255.0-(1-gel) for (c, gel) in zip(rgb, self.gel_color[:3])]
         #rgb = [c/255.0 for c in rgb]

--- a/gdtf.py
+++ b/gdtf.py
@@ -79,9 +79,17 @@ class DMX_GDTF():
         if (not dmx_mode): return []
         
         channels = dmx_mode.dmx_channels
-        footprint = max([max([o for o in ch.offset]) for ch in channels])
+        _fp=[]
+        for ch in channels:
+            if ch.offset is None:
+                continue
+            _fp.append(max(o for o in ch.offset))
+        footprint=max(_fp)
+
         dmx_channels = [{'id':'', 'default':0}]*footprint
         for ch in channels:
+            if ch.offset is None:
+                continue
             dmx_channels[ch.offset[0]-1] = {
                 'id':str(ch.logical_channels[0].channel_functions[0].attribute),
                 'default':DMX_GDTF.getValue(ch.logical_channels[0].channel_functions[0].default)
@@ -210,7 +218,6 @@ class DMX_GDTF():
                 obj_child.location[1] += position[1]
                 obj_child.location[2] += position[2]
                 scale = [geom.position.matrix[c][c] for c in range(3)]
-                obj_child.scale[0] *= scale[0]
                 obj_child.scale[1] *= scale[1]
                 obj_child.scale[2] *= scale[2]
 
@@ -246,9 +253,17 @@ class DMX_GDTF():
                         obj_child.location[0] += obj_parent.location[0]
                         obj_child.location[1] += obj_parent.location[1]
                         obj_child.location[2] += obj_parent.location[2]
-                    updateGeom(child_geom, d+1)
+                    try:
+                        updateGeom(child_geom, d+1)
+                    except Exception as e:
+                        #breakpoint()
+                        print("Update error", e), child_geom, d
 
-        updateGeom(profile)
+        try:
+            updateGeom(profile)
+        except Exception as e:
+            #breakpoint()
+            print("another error", e, profile)
 
         # Add target for manipulating fixture
         target = bpy.data.objects.new(name="Target", object_data=None)

--- a/gdtf.py
+++ b/gdtf.py
@@ -167,10 +167,13 @@ class DMX_GDTF():
         obj = bpy.context.view_layer.objects.selected[0]
         obj.users_collection[0].objects.unlink(obj)
         obj.rotation_euler = Euler((0, 0, 0), 'XYZ')
+        z=obj.dimensions.z
+        if z==0:
+            z=1
         obj.scale = (
             obj.scale.x*model.length/obj.dimensions.x,
             obj.scale.y*model.width/obj.dimensions.y,
-            obj.scale.z*model.height/obj.dimensions.z)
+            obj.scale.z*model.height/z)
         return obj
 
     @staticmethod

--- a/gdtf.py
+++ b/gdtf.py
@@ -99,10 +99,11 @@ class DMX_GDTF():
                     'id':'+'+str(ch.logical_channels[0].channel_functions[0].attribute),
                     'default':DMX_GDTF.getValue(ch.logical_channels[0].channel_functions[0].default, True)
                 }
-        
-        for i, ch in enumerate(dmx_channels):
-            if ('ColorAdd_' in ch['id']):
-                dmx_channels[i]['id'] = ch['id'][9:]
+        # ------------ stop shortening attribute names---------------
+        #for i, ch in enumerate(dmx_channels):
+        #    if ('ColorAdd_' in ch['id']):
+        #        dmx_channels[i]['id'] = ch['id'][9:]
+        # -----------------------------------------------------------
 
         return dmx_channels
         
@@ -165,6 +166,7 @@ class DMX_GDTF():
         file_3ds = profile._package.open(filename)
         load_3ds(file_3ds, bpy.context)
         obj = bpy.context.view_layer.objects.selected[0]
+        #breakpoint()
         obj.users_collection[0].objects.unlink(obj)
         obj.rotation_euler = Euler((0, 0, 0), 'XYZ')
         z=obj.dimensions.z

--- a/gdtf.py
+++ b/gdtf.py
@@ -118,6 +118,8 @@ class DMX_GDTF():
 
         if (primitive == 'Cube'):
             bpy.ops.mesh.primitive_cube_add(size=1.0)
+        elif (primitive == 'Pigtail'):
+            bpy.ops.mesh.primitive_cube_add(size=1.0)
         elif (primitive == 'Cylinder'):
             bpy.ops.mesh.primitive_cylinder_add(vertices=16, radius=0.5, depth=1.0)
         elif (primitive == 'Sphere'):
@@ -196,9 +198,6 @@ class DMX_GDTF():
                     obj = DMX_GDTF.loadglb(profile, model)
                 else:
                     obj = DMX_GDTF.load3ds(profile, model)
-            # 'Pigtail': ignore
-            elif (str(model.primitive_type) == 'Pigtail'):
-                pass
             # Blender primitives
             else:
                 obj = DMX_GDTF.loadBlenderPrimitive(model)
@@ -220,6 +219,11 @@ class DMX_GDTF():
                 scale = [geom.position.matrix[c][c] for c in range(3)]
                 obj_child.scale[1] *= scale[1]
                 obj_child.scale[2] *= scale[2]
+                if 'Pigtail' in geom.model:
+                    if not bpy.context.scene.dmx.display_pigtails:
+                        obj_child.scale[0] *= 0
+                        obj_child.scale[1] *= 0
+                        obj_child.scale[2] *= 0
 
                 # Beam geometry: add light source and emitter material
                 if (isinstance(geom, pygdtf.GeometryBeam)):

--- a/gdtf.py
+++ b/gdtf.py
@@ -143,7 +143,7 @@ class DMX_GDTF():
         return obj
 
     @staticmethod
-    def loadglb(profile, model):
+    def loadGlb(profile, model):
         #glbs must be loaded from a file, so we must unzip them
         folder_path = os.path.dirname(os.path.realpath(__file__))
         folder_path = os.path.join(folder_path, 'assets', 'models', profile.fixture_type_id)
@@ -166,7 +166,6 @@ class DMX_GDTF():
         file_3ds = profile._package.open(filename)
         load_3ds(file_3ds, bpy.context)
         obj = bpy.context.view_layer.objects.selected[0]
-        #breakpoint()
         obj.users_collection[0].objects.unlink(obj)
         obj.rotation_euler = Euler((0, 0, 0), 'XYZ')
         z=obj.dimensions.z
@@ -200,7 +199,7 @@ class DMX_GDTF():
             # 'Undefined': load from 3ds
             elif (str(model.primitive_type) == 'Undefined'):
                 if f"models/gltf/{model.file.name}.glb" in profile._package.namelist():
-                    obj = DMX_GDTF.loadglb(profile, model)
+                    obj = DMX_GDTF.loadGlb(profile, model)
                 else:
                     obj = DMX_GDTF.load3ds(profile, model)
             # Blender primitives
@@ -265,14 +264,12 @@ class DMX_GDTF():
                     try:
                         updateGeom(child_geom, d+1)
                     except Exception as e:
-                        #breakpoint()
-                        print("Update error", e), child_geom, d
+                        print("Error during geometry updates:", e), child_geom, d
 
         try:
             updateGeom(profile)
         except Exception as e:
-            #breakpoint()
-            print("another error", e, profile)
+            print("Another possible error during geometry updates:", e, profile)
 
         # Add target for manipulating fixture
         target = bpy.data.objects.new(name="Target", object_data=None)

--- a/panels/programmer.py
+++ b/panels/programmer.py
@@ -46,7 +46,7 @@ class DMX_OT_Programmer_Clear(Operator):
         scene.dmx.programmer_dimmer = 0.0
         scene.dmx.programmer_pan = 0.0
         scene.dmx.programmer_tilt = 0.0
-        scene.dmx.programmer_zoom = 0.0
+        scene.dmx.programmer_zoom = 0
         return {'FINISHED'}
 
 class DMX_OT_Programmer_SelectBodies(Operator):

--- a/panels/programmer.py
+++ b/panels/programmer.py
@@ -46,6 +46,7 @@ class DMX_OT_Programmer_Clear(Operator):
         scene.dmx.programmer_dimmer = 0.0
         scene.dmx.programmer_pan = 0.0
         scene.dmx.programmer_tilt = 0.0
+        scene.dmx.programmer_zoom = 0.0
         return {'FINISHED'}
 
 class DMX_OT_Programmer_SelectBodies(Operator):
@@ -128,6 +129,8 @@ class DMX_PT_Programmer(Panel):
 
         layout.prop(scene.dmx,"programmer_pan", text="Pan")
         layout.prop(scene.dmx,"programmer_tilt", text="Tilt")
+
+        layout.prop(scene.dmx,"programmer_zoom", text="Zoom")
 
         if (selected):
             layout.operator("dmx.clear", text="Clear")

--- a/panels/setup.py
+++ b/panels/setup.py
@@ -111,6 +111,21 @@ class DMX_PT_Setup_Volume(Panel):
         row.prop(context.scene.dmx, 'volume_density')
         row.enabled = (dmx.volume != None)
 
+class DMX_PT_Setup_Models(Panel):
+    bl_label = "Models"
+    bl_idname = "DMX_PT_Setup_Models"
+    bl_parent_id = "DMX_PT_Setup"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "DMX"
+    bl_context = "objectmode"
+    bl_options = {'DEFAULT_CLOSED'}
+
+    def draw(self, context):
+        layout = self.layout
+        dmx = context.scene.dmx
+        layout.prop(context.scene.dmx,'display_pigtails')
+
 # Panel #
 
 class DMX_PT_Setup(Panel):

--- a/pygdtf/__init__.py
+++ b/pygdtf/__init__.py
@@ -602,8 +602,8 @@ class DmxChannel(BaseNode):
         except ValueError:
             self.dmx_break = 'Overwrite'
         _offset = xml_node.attrib.get('Offset')
-        if _offset is None or _offset == 'None':
-            self.offset = 'None'
+        if _offset is None or _offset == 'None' or _offset =="":
+            self.offset = None
         else:
             self.offset = [int(i) for i in xml_node.attrib.get('Offset').split(',')]
         self.default = DmxValue(xml_node.attrib.get('Default', '0/1'))

--- a/pygdtf/__init__.py
+++ b/pygdtf/__init__.py
@@ -602,7 +602,7 @@ class DmxChannel(BaseNode):
         except ValueError:
             self.dmx_break = 'Overwrite'
         _offset = xml_node.attrib.get('Offset')
-        if _offset is None or _offset == 'None' or _offset =="":
+        if _offset is None or _offset == 'None' or _offset =='':
             self.offset = None
         else:
             self.offset = [int(i) for i in xml_node.attrib.get('Offset').split(',')]

--- a/util.py
+++ b/util.py
@@ -28,3 +28,25 @@ def getSceneRect():
                 if (obj.location[i] > max[i]): max[i] = obj.location[i]
 
     return (min, max)
+
+def rgb_to_cmy(rgb):
+    if (rgb) == [0,0,0]:
+        return [255,255,255]
+
+    c = 1 - rgb[0] / 255
+    m = 1 - rgb[1] / 255
+    y = 1 - rgb[2] / 255
+
+    min_cmy = min(c, m, y)
+    c = (c - min_cmy) / (1 - min_cmy)
+    m = (m - min_cmy) / (1 - min_cmy)
+    y = (y - min_cmy) / (1 - min_cmy)
+
+    return [int(c * 255), int(m * 255), int(y * 255)]
+
+def cmy_to_rgb(cmy):
+    rgb=[0,0,0]
+    rgb[0] = int(255 * (1.0 - cmy[0] / 255))
+    rgb[1] = int(255 * (1.0 - cmy[1] / 255))
+    rgb[2] = int(255 * (1.0 - cmy[2] / 255))
+    return rgb


### PR DESCRIPTION
This adds several things:

* initial Zoom support
* initial ColorSub_C/M/Y support
* fixed the ColorAdd_R/G/B attribute support (not sure how this worked before... perhaps the original devices used R, G, B instead of the GDTF attributes...?)
* added Pigtail settings - this is not updated in realtime but only during adding/editing of a device
* catch several crash errors

Please let me know if i miss some of the formats or variable camelCasing.
