### PR TITLE
Refactor model loading and add support for empty geometries and for GeometryReferences

### DIFF
--- a/data.py
+++ b/data.py
@@ -39,6 +39,7 @@ class DMX_Data():
         if (universe >= len(DMX_Data._universes)): return
         if (not bpy.context.scene.dmx.universes[universe]): return
         if (bpy.context.scene.dmx.universes[universe].input != 'BLENDERDMX'): return
+        if val > 255: return
         DMX_Data._universes[universe-1][addr-1] = val
 
     @staticmethod

--- a/fixture.py
+++ b/fixture.py
@@ -147,7 +147,7 @@ class DMX_Fixture(PropertyGroup):
 
         # Import and deep copy Fixture Model Collection
         gdtf_profile = DMX_GDTF.loadProfile(profile)
-        model_collection = DMX_Model.getFixtureModelCollection(gdtf_profile)
+        model_collection = DMX_Model.getFixtureModelCollection(gdtf_profile, self.mode)
         links = {}
         for obj in model_collection.objects:
             # Copy object
@@ -264,17 +264,24 @@ class DMX_Fixture(PropertyGroup):
             self.updateZoom(zoom)
 
     def updateDimmer(self, dimmer):
-        self.emitter_material.node_tree.nodes[1].inputs[STRENGTH].default_value = 10*(dimmer/255.0)
-        for light in self.lights:
-            light.object.data.energy = (dimmer/255.0) * light.object.data['flux']
+        try:
+            self.emitter_material.node_tree.nodes[1].inputs[STRENGTH].default_value = 10*(dimmer/255.0)
+            for light in self.lights:
+                light.object.data.energy = (dimmer/255.0) * light.object.data['flux']
+        except Exception as e:
+            print("Error updating dimmer", e)
+                
         return dimmer
 
     def updateRGB(self, rgb):
-        rgb = [c/255.0-(1-gel) for (c, gel) in zip(rgb, self.gel_color[:3])]
-        #rgb = [c/255.0 for c in rgb]
-        self.emitter_material.node_tree.nodes[1].inputs[COLOR].default_value = rgb + [1]
-        for light in self.lights:
-            light.object.data.color = rgb
+        try:
+            rgb = [c/255.0-(1-gel) for (c, gel) in zip(rgb, self.gel_color[:3])]
+            #rgb = [c/255.0 for c in rgb]
+            self.emitter_material.node_tree.nodes[1].inputs[COLOR].default_value = rgb + [1]
+            for light in self.lights:
+                light.object.data.color = rgb
+        except Exception as e:
+            print("Error updating RGB", e)
         return rgb
 
 
@@ -289,9 +296,12 @@ class DMX_Fixture(PropertyGroup):
         return cmy
 
     def updateZoom(self, zoom):
-        spot_size=zoom*3.1415/180.0
-        for light in self.lights:
-            light.object.data.spot_size=spot_size
+        try:
+            spot_size=zoom*3.1415/180.0
+            for light in self.lights:
+                light.object.data.spot_size=spot_size
+        except Exception as e:
+            print("Error updating zoom", e)
         return zoom
 
 

--- a/gdtf.py
+++ b/gdtf.py
@@ -7,8 +7,9 @@
 
 import os
 import bpy
+import copy
 
-from mathutils import Euler
+from mathutils import Euler, Matrix
 
 from dmx import pygdtf
 
@@ -143,28 +144,20 @@ class DMX_GDTF():
         return obj
 
     @staticmethod
-    def loadGlb(profile, model):
-        #glbs must be loaded from a file, so we must unzip them
-        folder_path = os.path.dirname(os.path.realpath(__file__))
-        folder_path = os.path.join(folder_path, 'assets', 'models', profile.fixture_type_id)
-        filename = f"models/gltf/{model.file.name}.glb"
-        profile._package.extract(filename, folder_path)
-        file_glb=os.path.join(folder_path, filename)
-        bpy.ops.import_scene.gltf(filepath=file_glb)
-        obj = bpy.context.view_layer.objects.selected[0]
-        obj.users_collection[0].objects.unlink(obj)
-        obj.rotation_euler = Euler((0, 0, 0), 'XYZ')
-        obj.scale = (
-            obj.scale.x*model.length/obj.dimensions.x,
-            obj.scale.y*model.width/obj.dimensions.y,
-            obj.scale.z*model.height/obj.dimensions.z)
-        return obj
+    def loadModel(profile, model):
+        current_path = os.path.dirname(os.path.realpath(__file__))
+        extract_to_folder_path = os.path.join(current_path, 'assets', 'models', profile.fixture_type_id)
+        
+        if model.file.extension.lower() == "3ds":
+            inside_zip_path =f"models/3ds/{model.file.name}.{model.file.extension}"
+            file_name = profile._package.open(inside_zip_path)
+            load_3ds(file_name, bpy.context)
+        else:
+            inside_zip_path = f"models/gltf/{model.file.name}.{model.file.extension}"
+            profile._package.extract(inside_zip_path, extract_to_folder_path)
+            file_name=os.path.join(extract_to_folder_path, inside_zip_path)
+            bpy.ops.import_scene.gltf(filepath=file_name)
 
-    @staticmethod
-    def load3ds(profile, model):
-        filename = 'models/3ds/'+model.file.name+'.3ds'
-        file_3ds = profile._package.open(filename)
-        load_3ds(file_3ds, bpy.context)
         obj = bpy.context.view_layer.objects.selected[0]
         obj.users_collection[0].objects.unlink(obj)
         obj.rotation_euler = Euler((0, 0, 0), 'XYZ')
@@ -176,14 +169,37 @@ class DMX_GDTF():
         return obj
 
     @staticmethod
-    def buildCollection(profile):
+    def buildCollection(profile, mode):
 
         # Create model collection
-        collection = bpy.data.collections.new(DMX_GDTF.getName(profile))
-
-        # Load 3ds objects from the GDTF profile
+        collection = bpy.data.collections.new(DMX_GDTF.getName(profile, mode))
         objs = {}
-        for model in profile.models:
+        # Get root geometry reference from the selected DMX Mode
+        dmx_mode = profile.get_dmx_mode_by_name(mode)
+        root_geometry = profile.get_geometry_by_name(dmx_mode.geometry)
+
+        def load_geometries(geometry):
+            """Load 3d models, primitives and shapes"""
+            
+            if isinstance(geometry, pygdtf.GeometryReference):
+                reference = profile.get_geometry_by_name(geometry.geometry)
+                geometry.model = reference.model
+
+            if geometry.model is None:
+                # Empty geometries are allowed as of GDTF 1.2
+                # If the size is 0, Blender will discard it, set it to something tiny
+                model=pygdtf.Model(name=geometry.name,
+                                   length=0.0001, width=0.0001, height=0.0001, primitive_type="Cube")
+                geometry.model = ""
+            else:
+                # Deepcopy the model because GeometryReference will modify the name
+                # Perhaps this could be done conditionally
+                # Also, we could maybe make a copy of the beam instance, if Blender supports it...
+                model = copy.deepcopy(profile.get_model_by_name(geometry.model))
+
+            if isinstance(geometry, pygdtf.GeometryReference):
+                model.name=geometry.name
+
             obj = None
             primitive = str(model.primitive_type)
             # Normalize 1.1 PrimitiveTypes
@@ -194,12 +210,12 @@ class DMX_GDTF():
             # BlenderDMX primitives
             if (str(model.primitive_type) in ['Base','Conventional','Head','Yoke']):
                 obj = DMX_GDTF.loadPrimitive(model)
-            # 'Undefined': load from 3ds
+            # 'Undefined': load from 3d
             elif (str(model.primitive_type) == 'Undefined'):
-                if f"models/gltf/{model.file.name}.glb" in profile._package.namelist():
-                    obj = DMX_GDTF.loadGlb(profile, model)
-                else:
-                    obj = DMX_GDTF.load3ds(profile, model)
+                try:
+                    obj = DMX_GDTF.loadModel(profile, model)
+                except Exception as e:
+                    print("Error importing 3D model:", e)
             # Blender primitives
             else:
                 obj = DMX_GDTF.loadBlenderPrimitive(model)
@@ -209,66 +225,81 @@ class DMX_GDTF():
                 objs[model.name] = obj
                 obj.hide_select = True
 
-        # Recursively update object position, rotation and scale
-        def updateGeom(geom, d=0):
-            if (d > 0):
-                # Add child position
-                position = [geom.position.matrix[c][3] for c in range(3)]
-                obj_child = objs[geom.name]
-                obj_child.location[0] += position[0]
-                obj_child.location[1] += position[1]
-                obj_child.location[2] += position[2]
-                scale = [geom.position.matrix[c][c] for c in range(3)]
-                obj_child.scale[0] *= scale[0]
-                obj_child.scale[1] *= scale[1]
-                obj_child.scale[2] *= scale[2]
-                if 'Pigtail' in geom.model:
-                    if not bpy.context.scene.dmx.display_pigtails:
-                        obj_child.scale[0] *= 0
-                        obj_child.scale[1] *= 0
-                        obj_child.scale[2] *= 0
+            if hasattr(geometry, "geometries"):
+                for sub_geometry in geometry.geometries:
+                    load_geometries(sub_geometry)
 
-                # Beam geometry: add light source and emitter material
-                if (isinstance(geom, pygdtf.GeometryBeam)):
-                    obj_child.visible_shadow = False
-                    light_data = bpy.data.lights.new(name="Spot", type='SPOT')
-                    light_data['flux'] = geom.luminous_flux
-                    light_data.energy = 0
-                    light_data.spot_size = geom.beam_angle*3.1415/180.0
-                    light_data.shadow_soft_size = geom.beam_radius
-                    light_object = bpy.data.objects.new(name="Spot", object_data=light_data)
-                    light_object.location = obj_child.location
-                    light_object.hide_select = True
-                    constraint = light_object.constraints.new('CHILD_OF')
-                    constraint.target = obj_child
-                    collection.objects.link(light_object)
 
-            if (len(geom.geometries) > 0):
-                for child_geom in geom.geometries:
-                    if (d > 0):
-                        # Constrain child to parent
-                        obj_parent = objs[geom.name]
-                        if (not child_geom.name in objs): continue
-                        obj_child = objs[child_geom.name]
-                        constraint = obj_child.constraints.new('CHILD_OF')
-                        constraint.target = obj_parent
-                        constraint.use_scale_x = False
-                        constraint.use_scale_y = False
-                        constraint.use_scale_z = False
-                        # Add parent position
-                        position = [geom.position.matrix[c][3] for c in range(3)]
-                        obj_child.location[0] += obj_parent.location[0]
-                        obj_child.location[1] += obj_parent.location[1]
-                        obj_child.location[2] += obj_parent.location[2]
-                    try:
-                        updateGeom(child_geom, d+1)
-                    except Exception as e:
-                        print("Error during recursive geometry updates", e), child_geom, d
+        def add_child_position(geometry):
+            """Add a child, create a light source and emitter material for beams"""
+            obj_child = objs[geometry.name]
 
-        try:
-            updateGeom(profile)
-        except Exception as e:
-            print("Error during geometry updates", e, profile)
+            position = Matrix(geometry.position.matrix).to_translation()
+            obj_child.location[0] += (position[0]*-1) # bug in the pygdtf?
+            obj_child.location[1] += position[1]
+            obj_child.location[2] += position[2]
+
+            obj_child.rotation_mode = "XYZ"
+            obj_child.rotation_euler = Matrix(geometry.position.matrix).to_euler('XYZ')
+
+            scale=Matrix(geometry.position.matrix).to_scale()
+            obj_child.scale[0] *= scale[0]
+            obj_child.scale[1] *= scale[1]
+            obj_child.scale[2] *= scale[2]
+
+            if 'Pigtail' in geometry.model:
+                if not bpy.context.scene.dmx.display_pigtails:
+                    obj_child.scale[0] *= 0
+                    obj_child.scale[1] *= 0
+                    obj_child.scale[2] *= 0
+
+            if isinstance(geometry, pygdtf.GeometryBeam) or isinstance(geometry, pygdtf.GeometryReference):
+                if isinstance(geometry, pygdtf.GeometryReference):
+                    geometry = profile.get_geometry_by_name(geometry.geometry)
+
+                obj_child.visible_shadow = False
+                light_data = bpy.data.lights.new(name="Spot", type='SPOT')
+                light_data['flux'] = geometry.luminous_flux
+                light_data.energy = 0
+                light_data.spot_size = geometry.beam_angle*3.1415/180.0
+                light_data.shadow_soft_size = geometry.beam_radius
+                light_object = bpy.data.objects.new(name="Spot", object_data=light_data)
+                light_object.location = obj_child.location
+                light_object.hide_select = True
+                constraint = light_object.constraints.new('CHILD_OF')
+                constraint.target = obj_child
+                collection.objects.link(light_object)
+
+        def constraint_child_to_parent(parent_geometry, child_geometry):
+            obj_parent = objs[parent_geometry.name]
+            if (not child_geometry.name in objs): return
+            obj_child = objs[child_geometry.name]
+            constraint = obj_child.constraints.new('CHILD_OF')
+            constraint.target = obj_parent
+            constraint.use_scale_x = False
+            constraint.use_scale_y = False
+            constraint.use_scale_z = False
+            # Add parent position
+            position = [parent_geometry.position.matrix[c][3] for c in range(3)]
+            obj_child.location[0] += obj_parent.location[0]
+            obj_child.location[1] += obj_parent.location[1]
+            obj_child.location[2] += obj_parent.location[2]
+
+        def update_geometry(geometry):
+            """Recursively update objects position, rotation and scale
+               and define parent/child constraints"""
+
+            add_child_position(geometry)
+
+            if hasattr(geometry, "geometries"):
+                if len(geometry.geometries) > 0:
+                    for child_geometry in geometry.geometries:
+                        constraint_child_to_parent(geometry, child_geometry)
+                        update_geometry(child_geometry)
+
+        # Load 3d objects from the GDTF profile
+        load_geometries(root_geometry)
+        update_geometry(root_geometry)
 
         # Add target for manipulating fixture
         target = bpy.data.objects.new(name="Target", object_data=None)
@@ -321,5 +352,6 @@ class DMX_GDTF():
         return collection
 
     @staticmethod
-    def getName(profile):
-        return profile.manufacturer + ", " + profile.name + ", " + (profile.revisions[-1].text if len(profile.revisions) else '')
+    def getName(profile, dmx_mode):
+        revision = profile.revisions[-1].text if len(profile.revisions) else ''
+        return f"{profile.manufacturer}, {profile.name}, {dmx_mode}, {revision}"

--- a/model.py
+++ b/model.py
@@ -18,13 +18,13 @@ class DMX_Model():
     #   This collection is then deep-copied by the Fixture class
     #   to create a fixture collection.
     @staticmethod
-    def getFixtureModelCollection(profile):
+    def getFixtureModelCollection(profile, dmx_mode):
 
         # Make sure the profile was passed as an argument, otherwise return None
         if (profile == None):
             return None
 
-        name = DMX_GDTF.getName(profile)
+        name = DMX_GDTF.getName(profile, dmx_mode)
 
         # If the fixture collection was already imported for this model
         # just return it
@@ -32,4 +32,4 @@ class DMX_Model():
             return bpy.data.collections[name]
 
         # Otherwise, build it from profile
-        return DMX_GDTF.buildCollection(profile)
+        return DMX_GDTF.buildCollection(profile, dmx_mode)


### PR DESCRIPTION
- get geometry tree root from DMX Mode link, this allows to only load models required for the geometry tree related to the chosen DMX mode
- unify loading logic for glb and 3ds loading, tested and confirmed that it works on Windows as well
- support empty geometries - (these act as a logic layer where needed)
- initial support for GeometryReferences https://gdtf.eu/gdtf/file-spec/geometry-collect/#geometry-type-reference . Geometries are loaded, placed and constrained correctly. What is still needed is to assign emitter to all beams - so beam now will need to be an array. I don't know this part of Blender too well, so i did not touch it at the moment. Also, as we do not have per geometry control (at the moment) it would be possible to "only" make linked copies of the beams, again, not sure what exactly does Blender support in this regard.

![image](https://user-images.githubusercontent.com/3680926/211156784-02c03a17-e366-45ae-812c-54f4067be82a.png)