### PR TITLE
Adding sACN support

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -21,6 +21,7 @@ from dmx.group import *
 from dmx.universe import *
 from dmx.data import *
 from dmx.artnet import *
+from dmx.acn import *
 from dmx.network import *
 
 from dmx.panels.setup import *
@@ -218,6 +219,9 @@ class DMX(PropertyGroup):
         if (dmx.artnet_enabled and dmx.artnet_status != 'online'):
             dmx.artnet_enabled = False
             dmx.artnet_status = 'offline'
+        if (dmx.sacn_enabled and dmx.artnet_status != 'online'):
+            dmx.sacn_enabled = False
+            dmx.artnet_status = 'offline'
 
         # Rebuild group runtime dictionary (evaluating if this is gonna stay here)
         #DMX_Group.runtime = {}
@@ -363,6 +367,18 @@ class DMX(PropertyGroup):
         items = DMX_Network.cards()
     )
 
+    # # DMX > sACN > Enable
+
+    def onsACNEnable(self, context):
+        dmx = bpy.context.scene.dmx
+        if (self.sacn_enabled):
+            DMX_ACN.enable()
+            dmx.artnet_status = 'online'
+            
+        else:
+            DMX_ACN.disable()
+            dmx.artnet_status = 'online'
+            
     # # DMX > ArtNet > Enable
 
     def onArtNetEnable(self, context):
@@ -378,6 +394,12 @@ class DMX(PropertyGroup):
         update = onArtNetEnable
     )
 
+    sacn_enabled : BoolProperty(
+        name = "Enable sACN Input",
+        description="Enables the input of DMX data throught sACN.",
+        default = False,
+        update = onsACNEnable
+    )
     # # DMX > ArtNet > Status
 
     artnet_status : EnumProperty(
@@ -673,6 +695,7 @@ def onLoadFile(scene):
 
     # Stop ArtNet
     DMX_ArtNet.disable()
+    DMX_ACN.disable()
 
 @bpy.app.handlers.persistent
 def onUndo(scene):
@@ -706,10 +729,12 @@ def register():
     # since 2.91.0 unregister is called also on Blender exit
     if bpy.app.version <= (2, 91, 0):
         atexit.register(DMX_ArtNet.disable)
+        atexit.register(DMX_ACN.disable)
 
 def unregister():
     # Stop ArtNet
     DMX_ArtNet.disable()
+    DMX_ACN.disable()
 
     try:
         # Unregister Base Classes

--- a/acn.py
+++ b/acn.py
@@ -1,0 +1,60 @@
+import bpy
+from dmx.sacn import sACNreceiver
+from dmx.data import DMX_Data
+
+
+class DMX_ACN:
+
+    _instance = None
+
+    def __init__(self):
+        super(DMX_ACN, self).__init__()
+        self.data = None
+        self.receiver = sACNreceiver()
+        self._dmx = bpy.context.scene.dmx
+
+    def callback(packet):  # packet type: sacn.DataPacket
+        dmx = bpy.context.scene.dmx
+        if packet.universe >= len(dmx.universes):
+            print("Not enough DMX universes set in BlenderDMX")
+            return
+        if not dmx.universes[packet.universe]:
+            print("sACN universe doesn't exist in BlenderDMX")
+            return
+        if dmx.universes[packet.universe].input != "sACN":
+            print("This DMX universe is not set to accept sACN data")
+            return
+        DMX_Data.set_universe(packet.universe, bytearray(packet.dmxData))
+        dmx.artnet_status = "online"
+
+    @staticmethod
+    def enable():
+        DMX_ACN._instance = DMX_ACN()
+        dmx = bpy.context.scene.dmx
+        DMX_ACN._instance.receiver.start()  # start the receiving thread
+
+        for universe in range(1, len(dmx.universes) + 1):
+            DMX_ACN._instance.receiver.register_listener(
+                "universe", DMX_ACN.callback, universe=universe
+            )
+        DMX_ACN._instance.receiver.join_multicast(1)
+        bpy.app.timers.register(DMX_ACN.run_render)
+        dmx.artnet_status = "listen"
+
+    @staticmethod
+    def disable():
+        dmx = bpy.context.scene.dmx
+        if DMX_ACN._instance:
+            DMX_ACN._instance.receiver.leave_multicast(1)
+            DMX_ACN._instance.receiver.remove_listener(DMX_ACN.callback)
+            DMX_ACN._instance.receiver.stop()
+            DMX_ACN._instance.data = None
+            dmx.artnet_status = "offline"
+
+        if bpy.app.timers.is_registered(DMX_ACN.run_render):
+            bpy.app.timers.unregister(DMX_ACN.run_render)
+
+    @staticmethod
+    def run_render():
+        bpy.context.scene.dmx.render()
+        return 1.0 / 60.0

--- a/artnet.py
+++ b/artnet.py
@@ -41,6 +41,7 @@ class ArtnetPacket:
         packet = ArtnetPacket()
         (packet.op_code, packet.ver, packet.sequence, packet.physical,
             packet.universe, packet.length) = unpack('!HHBBHH', udp_data[8:18])
+        (packet.universe,) = unpack('<H', udp_data[14:16])
 
         packet.data = unpack(
             '{0}s'.format(int(packet.length)),

--- a/data.py
+++ b/data.py
@@ -39,6 +39,7 @@ class DMX_Data():
         if (universe >= len(DMX_Data._universes)): return
         if (not bpy.context.scene.dmx.universes[universe]): return
         if (bpy.context.scene.dmx.universes[universe].input != 'BLENDERDMX'): return
+        if val > 255: return
         DMX_Data._universes[universe-1][addr-1] = val
 
     @staticmethod

--- a/data.py
+++ b/data.py
@@ -30,9 +30,9 @@ class DMX_Data():
 
     @staticmethod
     def get(universe, addr, n):
-        if (universe > len(DMX_Data._universes)): return bytearray([0]*n)
+        if (universe >= len(DMX_Data._universes)): return bytearray([0]*n)
         if (addr + n > 512): return bytearray([0]*n)
-        return DMX_Data._universes[universe-1][addr-1:addr+n-1]
+        return DMX_Data._universes[universe][addr-1:addr+n-1]
     
     @staticmethod
     def set(universe, addr, val):
@@ -40,7 +40,7 @@ class DMX_Data():
         if (not bpy.context.scene.dmx.universes[universe]): return
         if (bpy.context.scene.dmx.universes[universe].input != 'BLENDERDMX'): return
         if val > 255: return
-        DMX_Data._universes[universe-1][addr-1] = val
+        DMX_Data._universes[universe][addr-1] = val
 
     @staticmethod
     def set_universe(universe, data):

--- a/fixture.py
+++ b/fixture.py
@@ -147,7 +147,7 @@ class DMX_Fixture(PropertyGroup):
 
         # Import and deep copy Fixture Model Collection
         gdtf_profile = DMX_GDTF.loadProfile(profile)
-        model_collection = DMX_Model.getFixtureModelCollection(gdtf_profile)
+        model_collection = DMX_Model.getFixtureModelCollection(gdtf_profile, self.mode)
         links = {}
         for obj in model_collection.objects:
             # Copy object
@@ -264,17 +264,24 @@ class DMX_Fixture(PropertyGroup):
             self.updateZoom(zoom)
 
     def updateDimmer(self, dimmer):
-        self.emitter_material.node_tree.nodes[1].inputs[STRENGTH].default_value = 10*(dimmer/255.0)
-        for light in self.lights:
-            light.object.data.energy = (dimmer/255.0) * light.object.data['flux']
+        try:
+            self.emitter_material.node_tree.nodes[1].inputs[STRENGTH].default_value = 10*(dimmer/255.0)
+            for light in self.lights:
+                light.object.data.energy = (dimmer/255.0) * light.object.data['flux']
+        except Exception as e:
+            print("Error updating dimmer", e)
+                
         return dimmer
 
     def updateRGB(self, rgb):
-        rgb = [c/255.0-(1-gel) for (c, gel) in zip(rgb, self.gel_color[:3])]
-        #rgb = [c/255.0 for c in rgb]
-        self.emitter_material.node_tree.nodes[1].inputs[COLOR].default_value = rgb + [1]
-        for light in self.lights:
-            light.object.data.color = rgb
+        try:
+            rgb = [c/255.0-(1-gel) for (c, gel) in zip(rgb, self.gel_color[:3])]
+            #rgb = [c/255.0 for c in rgb]
+            self.emitter_material.node_tree.nodes[1].inputs[COLOR].default_value = rgb + [1]
+            for light in self.lights:
+                light.object.data.color = rgb
+        except Exception as e:
+            print("Error updating RGB", e)
         return rgb
 
 
@@ -289,9 +296,12 @@ class DMX_Fixture(PropertyGroup):
         return cmy
 
     def updateZoom(self, zoom):
-        spot_size=zoom*3.1415/180.0
-        for light in self.lights:
-            light.object.data.spot_size=spot_size
+        try:
+            spot_size=zoom*3.1415/180.0
+            for light in self.lights:
+                light.object.data.spot_size=spot_size
+        except Exception as e:
+            print("Error updating zoom", e)
         return zoom
 
 

--- a/gdtf.py
+++ b/gdtf.py
@@ -7,8 +7,9 @@
 
 import os
 import bpy
+import copy
 
-from mathutils import Euler
+from mathutils import Euler, Matrix
 
 from dmx import pygdtf
 
@@ -143,28 +144,20 @@ class DMX_GDTF():
         return obj
 
     @staticmethod
-    def loadGlb(profile, model):
-        #glbs must be loaded from a file, so we must unzip them
-        folder_path = os.path.dirname(os.path.realpath(__file__))
-        folder_path = os.path.join(folder_path, 'assets', 'models', profile.fixture_type_id)
-        filename = f"models/gltf/{model.file.name}.glb"
-        profile._package.extract(filename, folder_path)
-        file_glb=os.path.join(folder_path, filename)
-        bpy.ops.import_scene.gltf(filepath=file_glb)
-        obj = bpy.context.view_layer.objects.selected[0]
-        obj.users_collection[0].objects.unlink(obj)
-        obj.rotation_euler = Euler((0, 0, 0), 'XYZ')
-        obj.scale = (
-            obj.scale.x*model.length/obj.dimensions.x,
-            obj.scale.y*model.width/obj.dimensions.y,
-            obj.scale.z*model.height/obj.dimensions.z)
-        return obj
+    def loadModel(profile, model):
+        current_path = os.path.dirname(os.path.realpath(__file__))
+        extract_to_folder_path = os.path.join(current_path, 'assets', 'models', profile.fixture_type_id)
+        
+        if model.file.extension.lower() == "3ds":
+            inside_zip_path =f"models/3ds/{model.file.name}.{model.file.extension}"
+            file_name = profile._package.open(inside_zip_path)
+            load_3ds(file_name, bpy.context)
+        else:
+            inside_zip_path = f"models/gltf/{model.file.name}.{model.file.extension}"
+            profile._package.extract(inside_zip_path, extract_to_folder_path)
+            file_name=os.path.join(extract_to_folder_path, inside_zip_path)
+            bpy.ops.import_scene.gltf(filepath=file_name)
 
-    @staticmethod
-    def load3ds(profile, model):
-        filename = 'models/3ds/'+model.file.name+'.3ds'
-        file_3ds = profile._package.open(filename)
-        load_3ds(file_3ds, bpy.context)
         obj = bpy.context.view_layer.objects.selected[0]
         obj.users_collection[0].objects.unlink(obj)
         obj.rotation_euler = Euler((0, 0, 0), 'XYZ')
@@ -176,14 +169,37 @@ class DMX_GDTF():
         return obj
 
     @staticmethod
-    def buildCollection(profile):
+    def buildCollection(profile, mode):
 
         # Create model collection
-        collection = bpy.data.collections.new(DMX_GDTF.getName(profile))
-
-        # Load 3ds objects from the GDTF profile
+        collection = bpy.data.collections.new(DMX_GDTF.getName(profile, mode))
         objs = {}
-        for model in profile.models:
+        # Get root geometry reference from the selected DMX Mode
+        dmx_mode = profile.get_dmx_mode_by_name(mode)
+        root_geometry = profile.get_geometry_by_name(dmx_mode.geometry)
+
+        def load_geometries(geometry):
+            """Load 3d models, primitives and shapes"""
+            
+            if isinstance(geometry, pygdtf.GeometryReference):
+                reference = profile.get_geometry_by_name(geometry.geometry)
+                geometry.model = reference.model
+
+            if geometry.model is None:
+                # Empty geometries are allowed as of GDTF 1.2
+                # If the size is 0, Blender will discard it, set it to something tiny
+                model=pygdtf.Model(name=geometry.name,
+                                   length=0.0001, width=0.0001, height=0.0001, primitive_type="Cube")
+                geometry.model = ""
+            else:
+                # Deepcopy the model because GeometryReference will modify the name
+                # Perhaps this could be done conditionally
+                # Also, we could maybe make a copy of the beam instance, if Blender supports it...
+                model = copy.deepcopy(profile.get_model_by_name(geometry.model))
+
+            if isinstance(geometry, pygdtf.GeometryReference):
+                model.name=geometry.name
+
             obj = None
             primitive = str(model.primitive_type)
             # Normalize 1.1 PrimitiveTypes
@@ -194,12 +210,12 @@ class DMX_GDTF():
             # BlenderDMX primitives
             if (str(model.primitive_type) in ['Base','Conventional','Head','Yoke']):
                 obj = DMX_GDTF.loadPrimitive(model)
-            # 'Undefined': load from 3ds
+            # 'Undefined': load from 3d
             elif (str(model.primitive_type) == 'Undefined'):
-                if f"models/gltf/{model.file.name}.glb" in profile._package.namelist():
-                    obj = DMX_GDTF.loadGlb(profile, model)
-                else:
-                    obj = DMX_GDTF.load3ds(profile, model)
+                try:
+                    obj = DMX_GDTF.loadModel(profile, model)
+                except Exception as e:
+                    print("Error importing 3D model:", e)
             # Blender primitives
             else:
                 obj = DMX_GDTF.loadBlenderPrimitive(model)
@@ -209,66 +225,81 @@ class DMX_GDTF():
                 objs[model.name] = obj
                 obj.hide_select = True
 
-        # Recursively update object position, rotation and scale
-        def updateGeom(geom, d=0):
-            if (d > 0):
-                # Add child position
-                position = [geom.position.matrix[c][3] for c in range(3)]
-                obj_child = objs[geom.name]
-                obj_child.location[0] += position[0]
-                obj_child.location[1] += position[1]
-                obj_child.location[2] += position[2]
-                scale = [geom.position.matrix[c][c] for c in range(3)]
-                obj_child.scale[0] *= scale[0]
-                obj_child.scale[1] *= scale[1]
-                obj_child.scale[2] *= scale[2]
-                if 'Pigtail' in geom.model:
-                    if not bpy.context.scene.dmx.display_pigtails:
-                        obj_child.scale[0] *= 0
-                        obj_child.scale[1] *= 0
-                        obj_child.scale[2] *= 0
+            if hasattr(geometry, "geometries"):
+                for sub_geometry in geometry.geometries:
+                    load_geometries(sub_geometry)
 
-                # Beam geometry: add light source and emitter material
-                if (isinstance(geom, pygdtf.GeometryBeam)):
-                    obj_child.visible_shadow = False
-                    light_data = bpy.data.lights.new(name="Spot", type='SPOT')
-                    light_data['flux'] = geom.luminous_flux
-                    light_data.energy = 0
-                    light_data.spot_size = geom.beam_angle*3.1415/180.0
-                    light_data.shadow_soft_size = geom.beam_radius
-                    light_object = bpy.data.objects.new(name="Spot", object_data=light_data)
-                    light_object.location = obj_child.location
-                    light_object.hide_select = True
-                    constraint = light_object.constraints.new('CHILD_OF')
-                    constraint.target = obj_child
-                    collection.objects.link(light_object)
 
-            if (len(geom.geometries) > 0):
-                for child_geom in geom.geometries:
-                    if (d > 0):
-                        # Constrain child to parent
-                        obj_parent = objs[geom.name]
-                        if (not child_geom.name in objs): continue
-                        obj_child = objs[child_geom.name]
-                        constraint = obj_child.constraints.new('CHILD_OF')
-                        constraint.target = obj_parent
-                        constraint.use_scale_x = False
-                        constraint.use_scale_y = False
-                        constraint.use_scale_z = False
-                        # Add parent position
-                        position = [geom.position.matrix[c][3] for c in range(3)]
-                        obj_child.location[0] += obj_parent.location[0]
-                        obj_child.location[1] += obj_parent.location[1]
-                        obj_child.location[2] += obj_parent.location[2]
-                    try:
-                        updateGeom(child_geom, d+1)
-                    except Exception as e:
-                        print("Error during recursive geometry updates", e), child_geom, d
+        def add_child_position(geometry):
+            """Add a child, create a light source and emitter material for beams"""
+            obj_child = objs[geometry.name]
 
-        try:
-            updateGeom(profile)
-        except Exception as e:
-            print("Error during geometry updates", e, profile)
+            position = Matrix(geometry.position.matrix).to_translation()
+            obj_child.location[0] += (position[0]*-1) # bug in the pygdtf?
+            obj_child.location[1] += position[1]
+            obj_child.location[2] += position[2]
+
+            obj_child.rotation_mode = "XYZ"
+            obj_child.rotation_euler = Matrix(geometry.position.matrix).to_euler('XYZ')
+
+            scale=Matrix(geometry.position.matrix).to_scale()
+            obj_child.scale[0] *= scale[0]
+            obj_child.scale[1] *= scale[1]
+            obj_child.scale[2] *= scale[2]
+
+            if 'Pigtail' in geometry.model:
+                if not bpy.context.scene.dmx.display_pigtails:
+                    obj_child.scale[0] *= 0
+                    obj_child.scale[1] *= 0
+                    obj_child.scale[2] *= 0
+
+            if isinstance(geometry, pygdtf.GeometryBeam) or isinstance(geometry, pygdtf.GeometryReference):
+                if isinstance(geometry, pygdtf.GeometryReference):
+                    geometry = profile.get_geometry_by_name(geometry.geometry)
+
+                obj_child.visible_shadow = False
+                light_data = bpy.data.lights.new(name="Spot", type='SPOT')
+                light_data['flux'] = geometry.luminous_flux
+                light_data.energy = 0
+                light_data.spot_size = geometry.beam_angle*3.1415/180.0
+                light_data.shadow_soft_size = geometry.beam_radius
+                light_object = bpy.data.objects.new(name="Spot", object_data=light_data)
+                light_object.location = obj_child.location
+                light_object.hide_select = True
+                constraint = light_object.constraints.new('CHILD_OF')
+                constraint.target = obj_child
+                collection.objects.link(light_object)
+
+        def constraint_child_to_parent(parent_geometry, child_geometry):
+            obj_parent = objs[parent_geometry.name]
+            if (not child_geometry.name in objs): return
+            obj_child = objs[child_geometry.name]
+            constraint = obj_child.constraints.new('CHILD_OF')
+            constraint.target = obj_parent
+            constraint.use_scale_x = False
+            constraint.use_scale_y = False
+            constraint.use_scale_z = False
+            # Add parent position
+            position = [parent_geometry.position.matrix[c][3] for c in range(3)]
+            obj_child.location[0] += obj_parent.location[0]
+            obj_child.location[1] += obj_parent.location[1]
+            obj_child.location[2] += obj_parent.location[2]
+
+        def update_geometry(geometry):
+            """Recursively update objects position, rotation and scale
+               and define parent/child constraints"""
+
+            add_child_position(geometry)
+
+            if hasattr(geometry, "geometries"):
+                if len(geometry.geometries) > 0:
+                    for child_geometry in geometry.geometries:
+                        constraint_child_to_parent(geometry, child_geometry)
+                        update_geometry(child_geometry)
+
+        # Load 3d objects from the GDTF profile
+        load_geometries(root_geometry)
+        update_geometry(root_geometry)
 
         # Add target for manipulating fixture
         target = bpy.data.objects.new(name="Target", object_data=None)
@@ -321,5 +352,6 @@ class DMX_GDTF():
         return collection
 
     @staticmethod
-    def getName(profile):
-        return profile.manufacturer + ", " + profile.name + ", " + (profile.revisions[-1].text if len(profile.revisions) else '')
+    def getName(profile, dmx_mode):
+        revision = profile.revisions[-1].text if len(profile.revisions) else ''
+        return f"{profile.manufacturer}, {profile.name}, {dmx_mode}, {revision}"

--- a/model.py
+++ b/model.py
@@ -18,13 +18,13 @@ class DMX_Model():
     #   This collection is then deep-copied by the Fixture class
     #   to create a fixture collection.
     @staticmethod
-    def getFixtureModelCollection(profile):
+    def getFixtureModelCollection(profile, dmx_mode):
 
         # Make sure the profile was passed as an argument, otherwise return None
         if (profile == None):
             return None
 
-        name = DMX_GDTF.getName(profile)
+        name = DMX_GDTF.getName(profile, dmx_mode)
 
         # If the fixture collection was already imported for this model
         # just return it
@@ -32,4 +32,4 @@ class DMX_Model():
             return bpy.data.collections[name]
 
         # Otherwise, build it from profile
-        return DMX_GDTF.buildCollection(profile)
+        return DMX_GDTF.buildCollection(profile, dmx_mode)

--- a/panels/dmx.py
+++ b/panels/dmx.py
@@ -105,7 +105,7 @@ class DMX_PT_DMX_Universes(Panel):
         #layout.menu("dmx.menu.universe", text="...", icon="FILE_VOLUME")
 
 class DMX_PT_DMX_ArtNet(Panel):
-    bl_label = "ArtNet"
+    bl_label = "Ethernet"
     bl_idname = "DMX_PT_DMX_ArtNet"
     bl_parent_id = "DMX_PT_DMX"
     bl_space_type = "VIEW_3D"
@@ -124,6 +124,8 @@ class DMX_PT_DMX_ArtNet(Panel):
         
         row = layout.row()
         row.prop(dmx, "artnet_enabled")
+        row = layout.row()
+        row.prop(dmx, "sacn_enabled")
         row.enabled = (dmx.artnet_status == 'offline' or dmx.artnet_status == 'listen' or dmx.artnet_status == 'online')
 
         layout.label(text='Status: ' + layout.enum_item_name(dmx, 'artnet_status', dmx.artnet_status))

--- a/sacn/__init__.py
+++ b/sacn/__init__.py
@@ -1,0 +1,8 @@
+# re-export the classes available to consumers of this library
+from dmx.sacn.receiver import sACNreceiver, LISTEN_ON_OPTIONS  # noqa: F401
+from dmx.sacn.sender import sACNsender  # noqa: F401
+from dmx.sacn.messages.data_packet import DataPacket  # noqa: F401
+from dmx.sacn.messages.universe_discovery import UniverseDiscoveryPacket  # noqa: F401
+
+import logging
+logging.getLogger('sacn').addHandler(logging.NullHandler())

--- a/sacn/messages/data_packet.py
+++ b/sacn/messages/data_packet.py
@@ -1,0 +1,220 @@
+# This file is under MIT license. The license file can be obtained in the root directory of this module.
+
+"""
+This represents a framing layer and a DMP layer from the E1.31 Standard
+Information about sACN: http://tsp.esta.org/tsp/documents/docs/E1-31-2016.pdf
+"""
+
+from dmx.sacn.messages.root_layer import \
+    VECTOR_DMP_SET_PROPERTY, \
+    VECTOR_E131_DATA_PACKET, \
+    VECTOR_ROOT_E131_DATA, \
+    RootLayer, \
+    int_to_bytes, \
+    byte_tuple_to_int, \
+    make_flagsandlength
+
+
+class DataPacket(RootLayer):
+    def __init__(self, cid: tuple, sourceName: str, universe: int, dmxData: tuple = (), priority: int = 100,
+                 sequence: int = 0, streamTerminated: bool = False, previewData: bool = False,
+                 forceSync: bool = False, sync_universe: int = 0, dmxStartCode: int = 0x00):
+        super().__init__(126 + len(dmxData), cid, VECTOR_ROOT_E131_DATA)
+        self.sourceName: str = sourceName
+        self.priority = priority
+        self.syncAddr = sync_universe
+        self.universe = universe
+        self.option_StreamTerminated: bool = streamTerminated
+        self.option_PreviewData: bool = previewData
+        self.option_ForceSync: bool = forceSync
+        self.sequence = sequence
+        self.dmxStartCode = dmxStartCode
+        self.dmxData = dmxData
+
+    def __str__(self):
+        return f'sACN DataPacket: Universe: {self._universe}, Priority: {self._priority}, Sequence: {self._sequence}, ' \
+               f'CID: {self._cid}'
+
+    @property
+    def sourceName(self) -> str:
+        return self._sourceName
+
+    @sourceName.setter
+    def sourceName(self, sourceName: str):
+        if type(sourceName) is not str:
+            raise TypeError(f'sourceName must be a string! Type was {type(sourceName)}')
+        tmp_sourceName_length = len(str(sourceName).encode('UTF-8'))
+        if tmp_sourceName_length > 63:
+            raise ValueError(f'sourceName must be less than 64 bytes when UTF-8 encoded! "{sourceName}" is {tmp_sourceName_length} bytes')
+        self._sourceName = sourceName
+
+    @property
+    def priority(self) -> int:
+        return self._priority
+
+    @priority.setter
+    def priority(self, priority: int):
+        if type(priority) is not int:
+            raise TypeError(f'priority must be an integer! Type was {type(priority)}')
+        if priority not in range(0, 201):
+            raise ValueError(f'priority must be in range [0-200]! value was {priority}')
+        self._priority = priority
+
+    @property
+    def universe(self) -> int:
+        return self._universe
+
+    @universe.setter
+    def universe(self, universe: int):
+        if type(universe) is not int:
+            raise TypeError(f'universe must be an integer! Type was {type(universe)}')
+        if universe not in range(1, 64000):
+            raise ValueError(f'universe must be [1-63999]! value was {universe}')
+        self._universe = universe
+
+    @property
+    def syncAddr(self) -> int:
+        return self._syncAddr
+
+    @syncAddr.setter
+    def syncAddr(self, sync_universe: int):
+        if type(sync_universe) is not int:
+            raise TypeError(f'sync_universe must be an integer! Type was {type(sync_universe)}')
+        if sync_universe not in range(0, 64000):
+            raise ValueError(f'sync_universe must be [1-63999]! value was {sync_universe}')
+        self._syncAddr = sync_universe
+
+    @property
+    def sequence(self) -> int:
+        return self._sequence
+
+    @sequence.setter
+    def sequence(self, sequence: int):
+        if type(sequence) is not int:
+            raise TypeError(f'sequence must be an integer! Type was {type(sequence)}')
+        if sequence not in range(0, 256):
+            raise ValueError(f'sequence is a byte! values: [0-255]! value was {sequence}')
+        self._sequence = sequence
+
+    def sequence_increase(self):
+        self._sequence += 1
+        if self._sequence > 0xFF:
+            self._sequence = 0
+
+    @property
+    def dmxStartCode(self) -> int:
+        return self._dmxStartCode
+
+    @dmxStartCode.setter
+    def dmxStartCode(self, dmxStartCode: int):
+        """
+        DMX start code values: 0x00 for level data; 0xDD for per address priority data
+        """
+        if type(dmxStartCode) is not int:
+            raise TypeError(f'dmx start code must be an integer! Type was {type(dmxStartCode)}')
+        if dmxStartCode not in range(0, 256):
+            raise ValueError(f'dmx start code is a byte! values: [0-255]! value was {dmxStartCode}')
+        self._dmxStartCode = dmxStartCode
+
+    @property
+    def dmxData(self) -> tuple:
+        return self._dmxData
+
+    @dmxData.setter
+    def dmxData(self, data: tuple):
+        """
+        For legacy devices and to prevent errors, the length of the DMX data is normalized to 512
+        """
+        if len(data) > 512 or \
+                not all((isinstance(x, int) and (0 <= x <= 255)) for x in data):
+            raise ValueError(f'dmxData is a tuple with a max length of 512! The data in the tuple has to be valid bytes! '
+                             f'Length was {len(data)}')
+        newData = [0]*512
+        for i in range(0, min(len(data), 512)):
+            newData[i] = data[i]
+        self._dmxData = tuple(newData)
+        # in theory this class supports dynamic length, so the next line is correcting the length
+        self.length = 126 + len(self._dmxData)
+
+    def getBytes(self) -> tuple:
+        rtrnList = super().getBytes()
+        # Flags and Length Framing Layer:-------
+        rtrnList.extend(make_flagsandlength(self.length - 38))
+        # Vector Framing Layer:-----------------
+        rtrnList.extend(VECTOR_E131_DATA_PACKET)
+        # sourceName:---------------------------
+        # UTF-8 encode the string
+        tmpSourceName = str(self._sourceName).encode('UTF-8')
+        rtrnList.extend(tmpSourceName)
+        # pad to 64 bytes
+        rtrnList.extend([0] * (64 - len(tmpSourceName)))
+        # priority------------------------------
+        rtrnList.append(self._priority)
+        # syncAddress---------------------------
+        rtrnList.extend(int_to_bytes(self._syncAddr))
+        # sequence------------------------------
+        rtrnList.append(self._sequence)
+        # Options Flags:------------------------
+        tmpOptionsFlags = 0
+        # stream terminated:
+        tmpOptionsFlags += int(self.option_StreamTerminated) << 6
+        # preview data:
+        tmpOptionsFlags += int(self.option_PreviewData) << 7
+        # force synchronization
+        tmpOptionsFlags += int(self.option_ForceSync) << 5
+        rtrnList.append(tmpOptionsFlags)
+        # universe:-----------------------------
+        rtrnList.extend(int_to_bytes(self._universe))
+        # DMP Layer:---------------------------------------------------
+        # Flags and Length DMP Layer:-----------
+        rtrnList.extend(make_flagsandlength(self.length - 115))
+        # Vector DMP Layer:---------------------
+        rtrnList.append(VECTOR_DMP_SET_PROPERTY)
+        # Some static values (Address & Data Type, First Property addr, ...)
+        rtrnList.extend([0xa1, 0x00, 0x00, 0x00, 0x01])
+        # Length of the data:-------------------
+        lengthDmxData = len(self._dmxData)+1
+        rtrnList.extend(int_to_bytes(lengthDmxData))
+        # DMX data:-----------------------------
+        rtrnList.append(self._dmxStartCode)  # DMX Start Code
+        rtrnList.extend(self._dmxData)
+        return tuple(rtrnList)
+
+    @staticmethod
+    def make_data_packet(raw_data) -> 'DataPacket':
+        """
+        Converts raw byte data to a sACN DataPacket. Note that the raw bytes have to come from a 2016 sACN Message.
+        This does not support DMX Start code!
+        :param raw_data: raw bytes as tuple or list
+        :raises TypeError: when the binary data does not match the criteria for a valid DMX data-packet
+        :return: a DataPacket with the properties set like the raw bytes
+        """
+        # Check if the length is sufficient
+        if len(raw_data) < 126:
+            raise TypeError('The length of the provided data is not long enough! Min length is 126!')
+        # Check if the three Vectors are correct
+        if tuple(raw_data[18:22]) != tuple(VECTOR_ROOT_E131_DATA) or \
+           tuple(raw_data[40:44]) != tuple(VECTOR_E131_DATA_PACKET) or \
+           raw_data[117] != VECTOR_DMP_SET_PROPERTY:  # REMEMBER: when slicing: [inclusive:exclusive]
+            raise TypeError('Some of the vectors in the given raw data are not compatible to the E131 Standard!')
+
+        tmpPacket = DataPacket(cid=tuple(raw_data[22:38]), sourceName=bytes(raw_data[44:108]).decode('utf-8').replace('\0', ''),
+                               universe=byte_tuple_to_int(raw_data[113:115]))  # high byte first
+        tmpPacket.priority = raw_data[108]
+        tmpPacket.syncAddr = byte_tuple_to_int(raw_data[109:111])
+        tmpPacket.sequence = raw_data[111]
+        tmpPacket.option_PreviewData = bool(raw_data[112] & 0b10000000)  # use the 7th bit as preview_data
+        tmpPacket.option_StreamTerminated = bool(raw_data[112] & 0b01000000)  # use bit 6 as stream terminated
+        tmpPacket.option_ForceSync = bool(raw_data[112] & 0b00100000)  # use bit 5 as force sync
+        tmpPacket.dmxStartCode = raw_data[125]
+        tmpPacket.dmxData = raw_data[126:638]
+        return tmpPacket
+
+    def calculate_multicast_addr(self) -> str:
+        return calculate_multicast_addr(self.universe)
+
+
+def calculate_multicast_addr(universe: int) -> str:
+    hi_byte = universe >> 8  # a little bit shifting here
+    lo_byte = universe & 0xFF  # a little bit mask there
+    return f'239.255.{hi_byte}.{lo_byte}'

--- a/sacn/messages/data_packet_test.py
+++ b/sacn/messages/data_packet_test.py
@@ -1,0 +1,258 @@
+# This file is under MIT license. The license file can be obtained in the root directory of this module.
+
+import pytest
+from dmx.sacn.messages.data_packet import \
+    calculate_multicast_addr, \
+    DataPacket
+from dmx.sacn.messages.general_test import property_number_range_check
+
+
+def test_calculate_multicast_addr():
+    universe_1 = '239.255.0.1'
+    universe_63999 = '239.255.249.255'
+    assert calculate_multicast_addr(1) == universe_1
+    assert calculate_multicast_addr(63999) == universe_63999
+    packet = DataPacket(cid=tuple(range(0, 16)), sourceName="", universe=1)
+    assert packet.calculate_multicast_addr() == universe_1
+    packet = DataPacket(cid=tuple(range(0, 16)), sourceName="", universe=63999)
+    assert packet.calculate_multicast_addr() == universe_63999
+
+
+def test_byte_construction_and_deconstruction():
+    built_packet = DataPacket(
+        cid=(16, 1, 15, 2, 14, 3, 13, 4, 12, 5, 11, 6, 10, 7, 9, 8),
+        sourceName='Test Name',
+        universe=62000,
+        dmxData=tuple(x % 256 for x in range(0, 512)),
+        priority=195,
+        sequence=34,
+        streamTerminated=True,
+        previewData=True,
+        forceSync=True,
+        sync_universe=12000,
+        dmxStartCode=12)
+    read_packet = DataPacket.make_data_packet(built_packet.getBytes())
+    assert built_packet.dmxData == read_packet.dmxData
+    assert built_packet == read_packet
+
+
+def test_property_adjustment_and_deconstruction():
+    # Converting DataPacket -> bytes -> DataPacket should produce the same result,
+    # but with changed properties that are not the default
+    built_packet = DataPacket(
+        cid=(16, 1, 15, 2, 14, 3, 13, 4, 12, 5, 11, 6, 10, 7, 9, 8),
+        sourceName='Test Name',
+        universe=30)
+    built_packet.cid = tuple(range(16))
+    built_packet.sourceName = '2nd Test Name'
+    built_packet.universe = 31425
+    built_packet.dmxData = ((200,) + tuple(range(255, 0, -1)) + tuple(range(255)) + (0,))
+    built_packet.priority = 12
+    built_packet.sequence = 45
+    built_packet.option_StreamTerminated = True
+    built_packet.option_PreviewData = True
+    built_packet.option_ForceSync = True
+    built_packet.syncAddr = 34003
+    built_packet.dmxStartCode = 8
+    read_packet = DataPacket.make_data_packet(built_packet.getBytes())
+    assert read_packet.cid == tuple(range(16))
+    assert read_packet.sourceName == '2nd Test Name'
+    assert read_packet.universe == 31425
+    assert read_packet.dmxData == ((200,) + tuple(range(255, 0, -1)) + tuple(range(255)) + (0,))
+    assert read_packet.priority == 12
+    assert read_packet.sequence == 45
+    assert read_packet.option_StreamTerminated is True
+    assert read_packet.option_PreviewData is True
+    assert read_packet.option_ForceSync is True
+    assert read_packet.syncAddr == 34003
+    assert read_packet.dmxStartCode == 8
+
+
+def test_sequence_increment():
+    # Test that the sequence number can be increased and the wrap around at 255 is correct
+    built_packet = DataPacket(
+        cid=(16, 1, 15, 2, 14, 3, 13, 4, 12, 5, 11, 6, 10, 7, 9, 8),
+        sourceName='Test Name',
+        universe=30)
+    built_packet.sequence = 78
+    built_packet.sequence_increase()
+    assert built_packet.sequence == 79
+    built_packet.sequence = 255
+    built_packet.sequence_increase()
+    assert built_packet.sequence == 0
+
+
+def test_parse_data_packet():
+    # Use the example present in the E1.31 spec in appendix B
+    raw_data = [
+        # preamble size
+        0x00, 0x10,
+        # postamble size
+        0x00, 0x00,
+        # ACN packet identifier
+        0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
+        # flags and length
+        0x72, 0x7d,
+        # Root vector
+        0x00, 0x00, 0x00, 0x04,
+        # CID
+        0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
+        # Framing flags and length
+        0x72, 0x57,
+        # Framing vector
+        0x00, 0x00, 0x00, 0x02,
+        # Source name 'Source_A'
+        0x53, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x5f, 0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        # priority
+        0x64,
+        # sync address
+        0x1f, 0x1a,
+        # sequence number
+        0x9a,
+        # options
+        0x00,
+        # universe
+        0x00, 0x01,
+        # DMP flags and length
+        0x72, 0x0d,
+        # DMP vector
+        0x02,
+        # address type & data type
+        0xa1,
+        # first property address
+        0x00, 0x00,
+        # address increment
+        0x00, 0x01,
+        # property value count
+        0x02, 0x01,
+        # DMX start code
+        0x00,
+    ]
+    # DMX data (starting with 0 and incrementing with wrap around at 255)
+    dmx_data = [x % 256 for x in range(0, 512)]
+    raw_data.extend(dmx_data)
+
+    # parse raw data
+    packet = DataPacket.make_data_packet(raw_data)
+    assert packet.length == 638
+    assert packet._vector == (0x00, 0x00, 0x00, 0x04)
+    assert packet.cid == (0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e)
+    assert packet.sourceName == 'Source_A'
+    assert packet.priority == 100
+    assert packet.syncAddr == 7962
+    assert packet.sequence == 154
+    assert packet.option_ForceSync is False
+    assert packet.option_PreviewData is False
+    assert packet.option_StreamTerminated is False
+    assert packet.universe == 1
+    assert packet.dmxStartCode == 0
+    assert packet.dmxData == tuple(dmx_data)
+
+    # test for invalid data
+    # test for too short data arrays
+    for i in range(1, 126):
+        with pytest.raises(TypeError):
+            DataPacket.make_data_packet([x % 256 for x in range(0, i)])
+    # test for invalid vectors
+    with pytest.raises(TypeError):
+        DataPacket.make_data_packet([x % 256 for x in range(0, 126)])
+
+
+def test_str():
+    packet = DataPacket(
+        cid=(16, 1, 15, 2, 14, 3, 13, 4, 12, 5, 11, 6, 10, 7, 9, 8),
+        sourceName='Test',
+        universe=62000,
+        priority=195,
+        sequence=34)
+    assert packet.__str__() == 'sACN DataPacket: Universe: 62000, Priority: 195, Sequence: 34, CID: (16, 1, 15, 2, 14, 3, 13, 4, 12, 5, 11, 6, 10, 7, 9, 8)'
+
+
+def test_sourceName():
+    # test string has 25 characters but is 64 bytes (1 too many) when UTF-8 encoded
+    overlength_string = "𔑑覱֪I𤵎⠣Ķ'𫳪爓Û:𢏴㓑ò4𰬀鿹џ>𖬲膬ЩJ𞄇"
+    packet = DataPacket(cid=tuple(range(0, 16)), sourceName="", universe=1)
+    # test property setter
+    with pytest.raises(TypeError):
+        packet.sourceName = 0x33
+    with pytest.raises(ValueError):
+        packet.sourceName = overlength_string
+    # test constructor
+    with pytest.raises(ValueError):
+        DataPacket(cid=tuple(range(0, 16)), sourceName=overlength_string, universe=1)
+
+
+def test_priority():
+    packet = DataPacket(cid=tuple(range(0, 16)), sourceName="", universe=1)
+    # test property setter
+    def property(i): packet.priority = i
+    # test constructor for the same parameter
+    def constructor(i): DataPacket(tuple(range(0, 16)), sourceName="", universe=1, priority=i)
+    property_number_range_check(0, 200, property, constructor)
+
+
+def test_universe():
+    packet = DataPacket(cid=tuple(range(0, 16)), sourceName="", universe=1)
+    # test property setter
+    def property(i): packet.universe = i
+    # test constructor for the same parameter
+    def constructor(i): DataPacket(tuple(range(0, 16)), sourceName="", universe=i)
+    property_number_range_check(1, 63999, property, constructor)
+
+
+def test_sync_universe():
+    packet = DataPacket(cid=tuple(range(0, 16)), sourceName="", universe=1)
+    # test property setter
+    def property(i): packet.syncAddr = i
+    # test constructor for the same parameter
+    def constructor(i): DataPacket(tuple(range(0, 16)), sourceName="", universe=1, sync_universe=i)
+    property_number_range_check(0, 63999, property, constructor)
+
+
+def test_sequence():
+    packet = DataPacket(cid=tuple(range(0, 16)), sourceName="", universe=1)
+    # test property setter
+    def property(i): packet.sequence = i
+    # test constructor for the same parameter
+    def constructor(i): DataPacket(tuple(range(0, 16)), sourceName="", universe=1, sequence=i)
+    property_number_range_check(0, 255, property, constructor)
+
+
+def test_dmx_start_code():
+    packet = DataPacket(cid=tuple(range(0, 16)), sourceName="", universe=1)
+    # test property setter
+    def property(i): packet.dmxStartCode = i
+    # test constructor for the same parameter
+    def constructor(i): DataPacket(tuple(range(0, 16)), sourceName="", universe=1, dmxStartCode=i)
+    property_number_range_check(0, 255, property, constructor)
+
+
+def test_dmx_data():
+    packet = DataPacket(cid=tuple(range(0, 16)), sourceName="", universe=1)
+    # test valid lengths
+    for i in range(0, 512):
+        data = tuple(x % 256 for x in range(0, i))
+        # test property setter
+        packet.dmxData = data
+        assert len(packet.dmxData) == 512
+        assert packet.length == 638
+        # test constructor for the same parameter
+        packet2 = DataPacket(tuple(range(0, 16)), sourceName="", universe=1, dmxData=data)
+        assert len(packet2.dmxData) == 512
+        assert packet2.length == 638
+
+    def execute_universes_expect(data: tuple):
+        with pytest.raises(ValueError):
+            packet.dmxData = data
+        with pytest.raises(ValueError):
+            DataPacket(tuple(range(0, 16)), sourceName="", universe=1, dmxData=data)
+
+    # test for non-int and out of range values values in tuple
+    execute_universes_expect(tuple('string'))
+    execute_universes_expect(tuple(range(255, 257)))
+
+    # test for tuple-length > 512
+    execute_universes_expect(tuple(range(0, 513)))

--- a/sacn/messages/data_types.py
+++ b/sacn/messages/data_types.py
@@ -1,0 +1,29 @@
+# This file is under MIT license. The license file can be obtained in the root directory of this module.
+
+"""
+This file includes custom types for the usage in sACN packets.
+"""
+
+
+class CID:
+    """
+    CID stores a special case of a tuple that must have a length of 16 byte elements.
+    """
+
+    def __init__(self, cid: tuple):
+        self.value = cid
+
+    @property
+    def value(self) -> tuple:
+        return self._cid
+
+    @value.setter
+    def value(self, cid: tuple):
+        if type(cid) is not tuple:
+            raise TypeError(f'cid must be a 16 byte tuple! value was {cid}')
+        if (len(cid) != 16 or not all((isinstance(x, int) and (0 <= x <= 255)) for x in cid)):
+            raise ValueError(f'cid must be a 16 byte tuple! value was {cid}')
+        self._cid = cid
+
+    def __eq__(self, other: 'CID') -> bool:
+        return self.value == other.value

--- a/sacn/messages/data_types_test.py
+++ b/sacn/messages/data_types_test.py
@@ -1,0 +1,75 @@
+# This file is under MIT license. The license file can be obtained in the root directory of this module.
+
+
+import pytest
+from typing import Any, Callable
+from dmx.sacn.messages.data_types import CID
+
+
+def create_valid_cid() -> CID:
+    return CID(tuple(range(0, 16)))
+
+
+def cid_failing_test_cases(apply_to: Callable[[Any], None]):
+    def char_range(char1, char2):
+        """Generates the characters from `c1` to `c2`, ranged just like python."""
+        for c in range(ord(char1), ord(char2)):
+            yield chr(c)
+
+    # test that constructor validates cid
+    with pytest.raises(ValueError):
+        apply_to(tuple(char_range('A', 'Q')))
+    # test that CID must be 16 elements
+    with pytest.raises(ValueError):
+        apply_to(tuple(range(0, 17)))
+    with pytest.raises(ValueError):
+        apply_to(tuple(range(0, 15)))
+    # test that CID only contains valid byte values
+    with pytest.raises(ValueError):
+        apply_to(tuple(range(250, 266)))
+    with pytest.raises(ValueError):
+        apply_to(tuple(char_range('b', 'r')))
+    # test that CID is a tuple
+    with pytest.raises(TypeError):
+        apply_to(range(0, 16))
+
+
+def test_cid_constructor():
+    # normal values must work
+    tuple1 = tuple(range(0, 16))
+    tuple2 = tuple(range(1, 17))
+    cid1 = CID(tuple1)
+    cid2 = CID(tuple2)
+    assert cid1.value == tuple1
+    assert cid2.value == tuple2
+
+    def apply_constructor(value) -> None:
+        CID(value)
+
+    cid_failing_test_cases(apply_constructor)
+
+
+def test_cid_setter():
+    tuple1 = tuple(range(0, 16))
+    tuple2 = tuple(range(1, 17))
+
+    cid = CID(tuple(range(2, 18)))
+    # normal values must work
+    cid.value = tuple1
+    assert cid.value == tuple1
+    cid.value = tuple2
+    assert cid.value == tuple2
+
+    def apply_setter(value) -> None:
+        cid.value = value
+
+    cid_failing_test_cases(apply_setter)
+
+
+def test_cid_equals():
+    tuple1 = tuple(range(0, 16))
+    tuple2 = tuple(range(0, 16))
+
+    cid1 = CID(tuple1)
+    cid2 = CID(tuple2)
+    assert cid1 == cid2

--- a/sacn/messages/general_test.py
+++ b/sacn/messages/general_test.py
@@ -1,0 +1,15 @@
+# This file is under MIT license. The license file can be obtained in the root directory of this module.
+
+import pytest
+
+
+def property_number_range_check(lower_bound: int, upper_bound: int, *functions):
+    for function in functions:
+        for i in range(lower_bound, upper_bound + 1):
+            function(i)
+        with pytest.raises(ValueError):
+            function(lower_bound - 1)
+        with pytest.raises(ValueError):
+            function(upper_bound + 1)
+        with pytest.raises(TypeError):
+            function('Text')

--- a/sacn/messages/root_layer.py
+++ b/sacn/messages/root_layer.py
@@ -1,0 +1,104 @@
+# This file is under MIT license. The license file can be obtained in the root directory of this module.
+
+
+"""
+This represents a root layer of an ACN Message.
+Information about sACN: http://tsp.esta.org/tsp/documents/docs/E1-31-2016.pdf
+"""
+
+_FIRST_INDEX = \
+    (0, 0x10, 0, 0, 0x41, 0x53, 0x43, 0x2d, 0x45,
+     0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00)
+
+VECTOR_E131_DATA_PACKET = (0, 0, 0, 0x02)
+VECTOR_DMP_SET_PROPERTY = 0x02
+VECTOR_ROOT_E131_DATA = (0, 0, 0, 0x4)
+
+VECTOR_ROOT_E131_EXTENDED = (0, 0, 0, 0x8)
+
+VECTOR_E131_EXTENDED_SYNCHRONIZATION = (0, 0, 0, 0x1)
+VECTOR_E131_EXTENDED_DISCOVERY = (0, 0, 0, 0x2)
+VECTOR_UNIVERSE_DISCOVERY_UNIVERSE_LIST = (0, 0, 0, 0x1)
+
+
+class RootLayer:
+    def __init__(self, length: int, cid: tuple, vector: tuple):
+        self.length = length
+        if (len(vector) != 4):
+            raise ValueError('the length of the vector is not 4!')
+        self._vector = vector
+        self.cid = cid
+
+    def getBytes(self) -> list:
+        '''Returns the Root layer as list with bytes'''
+        tmpList = []
+        tmpList.extend(_FIRST_INDEX)
+        # first append the high byte from the Flags and Length
+        # high 4 bit: 0x7 then the bits 8-11(indexes) from _length
+        length = self.length - 16
+        tmpList.extend(make_flagsandlength(length))
+
+        tmpList.extend(self._vector)
+        tmpList.extend(self._cid)
+        return tmpList
+
+    @property
+    def length(self) -> int:
+        return self._length
+
+    @length.setter
+    def length(self, value: int):
+        self._length = value & 0xFFF  # only use the least 12-Bit
+
+    @property
+    def cid(self) -> tuple:
+        return self._cid
+
+    @cid.setter
+    def cid(self, cid: tuple):
+        if type(cid) is not tuple:
+            raise TypeError(f'cid must be a 16 byte tuple! value was {cid}')
+        if (len(cid) != 16 or not all((isinstance(x, int) and (0 <= x <= 255)) for x in cid)):
+            raise ValueError(f'cid must be a 16 byte tuple! value was {cid}')
+        self._cid = cid
+
+    def __eq__(self, other):
+        if self.__class__ != other.__class__:
+            return False
+        return self.__dict__ == other.__dict__
+
+
+def int_to_bytes(integer_value: int) -> list:
+    """
+    Converts a single integer number to an list with the length 2 with highest
+    byte first.
+    The returned list contains values in the range [0-255]
+    :param integer: the integer to convert
+    :return: the list with the high byte first
+    """
+    if not (isinstance(integer_value, int) and 0 <= integer_value <= 65535):
+        raise ValueError(f'integer_value to be packed must be unsigned short: [0-65535]! value was {integer_value}')
+    return [(integer_value >> 8) & 0xFF, integer_value & 0xFF]
+
+
+def byte_tuple_to_int(in_tuple: tuple) -> int:
+    """
+    Converts two element byte tuple (highest first) to integer.
+    :param in_tuple: the integer to convert
+    :return: the integer value
+    """
+    if ((len(in_tuple) != 2) or not all(isinstance(x, int) for x in in_tuple) or not all(0 <= x <= 255 for x in in_tuple)):
+        raise ValueError(f'in_tuple must be a two byte tuple! value was {in_tuple}')
+    return int((in_tuple[0] << 8) + in_tuple[1])
+
+
+def make_flagsandlength(in_length: int) -> list:
+    """
+    Converts a length value in a Flags and Length list with two bytes in the
+    correct order.
+    :param length: the length to convert. should be 12-bit value
+    :return: the list with the two bytes
+    """
+    if (in_length > 0xFFF):
+        raise ValueError(f'length must be no greater than a 12-bit value! value was {in_length}')
+    return [(0x7 << 4) + ((in_length & 0xF00) >> 8), in_length & 0xFF]

--- a/sacn/messages/root_layer_test.py
+++ b/sacn/messages/root_layer_test.py
@@ -1,0 +1,117 @@
+# This file is under MIT license. The license file can be obtained in the root directory of this module.
+
+import pytest
+from dmx.sacn.messages.root_layer import \
+    byte_tuple_to_int, \
+    int_to_bytes, \
+    make_flagsandlength, \
+    RootLayer
+
+
+def test_int_to_bytes():
+    assert int_to_bytes(0xFFFF) == [0xFF, 0xFF]
+    assert int_to_bytes(0x1234) == [0x12, 0x34]
+    # test that the value cannot exceed two bytes
+    with pytest.raises(ValueError):
+        int_to_bytes(0x123456)
+    assert int_to_bytes(0x0001) == [0x00, 0x01]
+
+
+def test_byte_tuple_to_int():
+    assert byte_tuple_to_int((0x00, 0x00)) == 0x0000
+    assert byte_tuple_to_int((0xFF, 0xFF)) == 0xFFFF
+    assert byte_tuple_to_int((0x12, 0x34)) == 0x1234
+    # test different length of tuples
+    with pytest.raises(ValueError):
+        byte_tuple_to_int(())
+    with pytest.raises(TypeError):
+        byte_tuple_to_int(1)
+    with pytest.raises(ValueError):
+        byte_tuple_to_int((1, 2, 3))
+    with pytest.raises(ValueError):
+        byte_tuple_to_int((1, 'string'))
+    with pytest.raises(ValueError):
+        byte_tuple_to_int((1, 500))
+
+
+def test_eq():
+    cid = tuple(range(0, 16))
+    cid2 = tuple(range(1, 17))
+    vec = tuple(range(0, 4))
+    vec2 = tuple(range(1, 5))
+    assert RootLayer(0, cid, vec) == RootLayer(0, cid, vec)
+    assert RootLayer(0, cid, vec) != RootLayer(1, cid, vec)
+    assert RootLayer(0, cid, vec) != RootLayer(0, cid, vec2)
+    assert RootLayer(0, cid, vec) != RootLayer(0, cid2, vec)
+    assert (RootLayer(0, cid, vec) == (1, 2, 3)) is False
+
+
+def test_make_flagsandlength():
+    assert make_flagsandlength(0x123) == [0x71, 0x23]
+    with pytest.raises(ValueError):
+        assert make_flagsandlength(0x1234) == [0x72, 0x34]
+    assert make_flagsandlength(0x001) == [0x70, 0x01]
+
+
+def test_cid():
+    cid1 = tuple(range(0, 16))
+    cid2 = tuple(range(1, 17))
+    vector1 = (1, 2, 3, 4)
+
+    def char_range(char1, char2):
+        """Generates the characters from `c1` to `c2`, ranged just like python."""
+        for c in range(ord(char1), ord(char2)):
+            yield chr(c)
+
+    # test constructor
+    packet = RootLayer(123, cid1, vector1)
+    assert packet.cid == cid1
+    packet.cid = cid2
+    assert packet.cid == cid2
+    # test that constructor validates cid
+    with pytest.raises(ValueError):
+        RootLayer(length=123, cid=tuple(char_range('A', 'Q')), vector=vector1)
+    # test that CID must be 16 elements
+    with pytest.raises(ValueError):
+        packet.cid = tuple(range(0, 17))
+    with pytest.raises(ValueError):
+        packet.cid = tuple(range(0, 15))
+    # test that CID only contains valid byte values
+    with pytest.raises(ValueError):
+        packet.cid = tuple(range(250, 266))
+    with pytest.raises(ValueError):
+        packet.cid = tuple(char_range('b', 'r'))
+    # test that CID is a tuple
+    with pytest.raises(TypeError):
+        packet.cid = range(0, 16)
+
+
+def test_root_layer_bytes():
+    cid = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
+    vector = (1, 2, 3, 4)
+    # test that the vector length must be 4
+    with pytest.raises(ValueError):
+        RootLayer(0, cid, ())
+    # test that the cid length must be 16
+    with pytest.raises(ValueError):
+        RootLayer(0, (), vector)
+    packet = RootLayer(0x123456, cid, vector)
+    shouldBe = [
+        # initial static vector
+        0, 0x10, 0, 0, 0x41, 0x53, 0x43, 0x2d, 0x45,
+        0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
+        # length value
+        0x74, 0x46
+    ]
+    # vector
+    shouldBe.extend(vector)
+    # cid
+    shouldBe.extend(cid)
+    assert packet.getBytes() == shouldBe
+
+
+def test_int_byte_transitions():
+    # test the full 0-65534 range, though only using 0-63999 currently
+    for input_i in range(65536):
+        converted_i = byte_tuple_to_int(tuple(int_to_bytes(input_i)))
+        assert input_i == converted_i

--- a/sacn/messages/sync_packet.py
+++ b/sacn/messages/sync_packet.py
@@ -1,0 +1,77 @@
+# This file is under MIT license. The license file can be obtained in the root directory of this module.
+
+"""
+This implements the sync packet from the E1.31 standard.
+Information about sACN: http://tsp.esta.org/tsp/documents/docs/E1-31-2016.pdf
+"""
+from dmx.sacn.messages.root_layer import \
+    VECTOR_ROOT_E131_EXTENDED, \
+    VECTOR_E131_EXTENDED_SYNCHRONIZATION, \
+    RootLayer, \
+    byte_tuple_to_int, \
+    int_to_bytes, \
+    make_flagsandlength
+
+
+class SyncPacket(RootLayer):
+    def __init__(self, cid: tuple, syncAddr: int, sequence: int = 0):
+        self.syncAddr = syncAddr
+        self.sequence = sequence
+        super().__init__(49, cid, VECTOR_ROOT_E131_EXTENDED)
+
+    @property
+    def syncAddr(self) -> int:
+        return self._syncAddr
+
+    @syncAddr.setter
+    def syncAddr(self, sync_universe: int):
+        if type(sync_universe) is not int:
+            raise TypeError(f'sync_universe must be an integer! Type was {type(sync_universe)}')
+        if sync_universe not in range(1, 64000):
+            raise ValueError(f'sync_universe must be [1-63999]! value was {sync_universe}')
+        self._syncAddr = sync_universe
+
+    @property
+    def sequence(self) -> int:
+        return self._sequence
+
+    @sequence.setter
+    def sequence(self, sequence: int):
+        if type(sequence) is not int:
+            raise TypeError('sequence must be an integer')
+        if sequence not in range(0, 256):
+            raise ValueError(f'sequence is a byte! values: [0-255]! value was {sequence}')
+        self._sequence = sequence
+
+    def sequence_increase(self):
+        self._sequence += 1
+        if self._sequence > 0xFF:
+            self._sequence = 0
+
+    def getBytes(self) -> list:
+        rtrnList = super().getBytes()
+        rtrnList.extend(make_flagsandlength(self.length - 38))
+        rtrnList.extend(VECTOR_E131_EXTENDED_SYNCHRONIZATION)
+        rtrnList.append(self._sequence)
+        rtrnList.extend(int_to_bytes(self._syncAddr))
+        rtrnList.extend((0, 0))  # the empty reserved slots
+        return rtrnList
+
+    @staticmethod
+    def make_sync_packet(raw_data) -> 'SyncPacket':
+        """
+        Converts raw byte data to a sACN SyncPacket. Note that the raw bytes have to come from a 2016 sACN Message.
+        :param raw_data: raw bytes as tuple or list
+        :return: a SyncPacket with the properties set like the raw bytes
+        """
+        # Check if the length is sufficient
+        if len(raw_data) < 47:
+            raise TypeError('The length of the provided data is not long enough! Min length is 47!')
+        # Check if the three Vectors are correct
+        if tuple(raw_data[18:22]) != tuple(VECTOR_ROOT_E131_EXTENDED) or \
+           tuple(raw_data[40:44]) != tuple(VECTOR_E131_EXTENDED_SYNCHRONIZATION):
+            # REMEMBER: when slicing: [inclusive:exclusive]
+            raise TypeError('Some of the vectors in the given raw data are not compatible to the E131 Standard!')
+        tmpPacket = SyncPacket(cid=tuple(raw_data[22:38]), syncAddr=byte_tuple_to_int(raw_data[45:47]))
+        tmpPacket.sequence = raw_data[44]
+        return tmpPacket

--- a/sacn/messages/sync_packet_test.py
+++ b/sacn/messages/sync_packet_test.py
@@ -1,0 +1,131 @@
+# This file is under MIT license. The license file can be obtained in the root directory of this module.
+
+import pytest
+from dmx.sacn.messages.sync_packet import SyncPacket
+from dmx.sacn.messages.general_test import property_number_range_check
+
+
+def test_constructor():
+    # positive tests
+    cid = tuple(range(0, 16))
+    syncAddr = 12
+    sequence = 127
+    packet = SyncPacket(cid, syncAddr, sequence)
+    assert packet.length == 49
+    assert packet.cid == cid
+    assert packet.syncAddr == syncAddr
+    assert packet.sequence == sequence
+    # using wrong values for CID
+    with pytest.raises(ValueError):
+        SyncPacket(tuple(range(0, 17)), syncAddr, sequence)
+
+
+def test_sync_universe():
+    packet = SyncPacket(tuple(range(0, 16)), 1, 1)
+    # test property setter
+    def property(i): packet.syncAddr = i
+    # test constructor for the same parameter
+    def constructor(i): SyncPacket(tuple(range(0, 16)), i, 1)
+    property_number_range_check(1, 63999, property, constructor)
+
+
+def test_sequence():
+    packet = SyncPacket(tuple(range(0, 16)), 1, 1)
+    # test property setter
+    def property(i): packet.sequence = i
+    # test constructor for the same parameter
+    def constructor(i): SyncPacket(tuple(range(0, 16)), 1, i)
+    property_number_range_check(0, 255, property, constructor)
+
+
+def test_sequence_increment():
+    # Test that the sequence number can be increased and the wrap around at 255 is correct
+    built_packet = SyncPacket(tuple(range(0, 16)), 1, 1)
+    built_packet.sequence = 78
+    built_packet.sequence_increase()
+    assert built_packet.sequence == 79
+    built_packet.sequence = 255
+    built_packet.sequence_increase()
+    assert built_packet.sequence == 0
+
+
+def test_get_bytes():
+    # Use the example present in the E1.31 spec in appendix B
+    cid = (0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e)
+    syncAddr = 7962
+    sequence = 67  # Note: the spec states 367, which is a mistake in the spec
+    packet = SyncPacket(cid, syncAddr, sequence)
+    assert packet.getBytes() == [
+        # preamble size
+        0x00, 0x10,
+        # postamble size
+        0x00, 0x00,
+        # ACN packet identifier
+        0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
+        # flags and length; again a mistake in the E1.31 spec, as this states '0x70, 0x30'
+        # this would violate the parent spec E1.17 (ACN) section 2.4.2
+        0x70, 0x21,
+        # Root vector
+        0x00, 0x00, 0x00, 0x08,
+        # CID
+        0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
+        # Framing flags and length; again propably a mistake as with the flags and length above
+        0x70, 0x0b,
+        # Framing vector
+        0x00, 0x00, 0x00, 0x01,
+        # sequence number
+        0x43,
+        # sync address
+        0x1f, 0x1a,
+        # reserved fields
+        0x00, 0x00,
+    ]
+
+
+def test_parse_sync_packet():
+    # Use the example present in the E1.31 spec in appendix B
+    raw_data = [
+        # preamble size
+        0x00, 0x10,
+        # postamble size
+        0x00, 0x00,
+        # ACN packet identifier
+        0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
+        # flags and length; again a mistake in the E1.31 spec, as this states '0x70, 0x30'
+        # this would violate the parent spec E1.17 (ACN) section 2.4.2
+        0x70, 0x21,
+        # Root vector
+        0x00, 0x00, 0x00, 0x08,
+        # CID
+        0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
+        # Framing flags and length; again propably a mistake as with the flags and length above
+        0x70, 0x0b,
+        # Framing vector
+        0x00, 0x00, 0x00, 0x01,
+        # sequence number
+        0x43,
+        # sync address
+        0x1f, 0x1a,
+        # reserved fields
+        0x00, 0x00,
+    ]
+    packet = SyncPacket.make_sync_packet(raw_data)
+    assert packet.length == 49
+    assert packet.cid == (0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e)
+    assert packet.sequence == 67
+    assert packet.syncAddr == 7962
+
+    # test for invalid data
+    # test for too short data arrays
+    for i in range(1, 47):
+        with pytest.raises(TypeError):
+            SyncPacket.make_sync_packet([x % 256 for x in range(0, i)])
+    # test for invalid vectors
+    with pytest.raises(TypeError):
+        SyncPacket.make_sync_packet([x % 256 for x in range(0, 47)])
+
+
+def test_byte_construction_and_deconstruction():
+    built_packet = SyncPacket(tuple(range(0, 16)), 12, 127)
+    read_packet = SyncPacket.make_sync_packet(built_packet.getBytes())
+    assert built_packet == read_packet

--- a/sacn/messages/universe_discovery.py
+++ b/sacn/messages/universe_discovery.py
@@ -1,0 +1,168 @@
+"""
+This class represents an universe discovery packet of the E1.31 Standard.
+"""
+from typing import List
+
+from dmx.sacn.messages.root_layer import \
+    VECTOR_ROOT_E131_EXTENDED, \
+    VECTOR_E131_EXTENDED_DISCOVERY, \
+    VECTOR_UNIVERSE_DISCOVERY_UNIVERSE_LIST,\
+    RootLayer, \
+    int_to_bytes, \
+    byte_tuple_to_int, \
+    make_flagsandlength
+
+
+class UniverseDiscoveryPacket(RootLayer):
+    def __init__(self, cid: tuple, sourceName: str, universes: tuple, page: int = 0, lastPage: int = 0):
+        self.sourceName: str = sourceName
+        self.page: int = page
+        self.lastPage: int = lastPage
+        self.universes: tuple = universes
+        super().__init__((len(universes) * 2) + 120, cid, VECTOR_ROOT_E131_EXTENDED)
+
+    @property
+    def sourceName(self) -> str:
+        return self._sourceName
+
+    @sourceName.setter
+    def sourceName(self, sourceName: str):
+        if type(sourceName) is not str:
+            raise TypeError(f'sourceName must be a string! Type was {type(sourceName)}')
+        tmp_sourceName_length = len(str(sourceName).encode('UTF-8'))
+        if tmp_sourceName_length > 63:
+            raise ValueError(f'sourceName must be less than 64 bytes when UTF-8 encoded! "{sourceName}" is {tmp_sourceName_length} bytes')
+        self._sourceName = sourceName
+
+    @property
+    def page(self) -> int:
+        return self._page
+
+    @page.setter
+    def page(self, page: int):
+        if type(page) is not int:
+            raise TypeError(f'Page must be an integer! Type was {type(page)}')
+        if page not in range(0, 256):
+            raise ValueError(f'Page is a byte! values: [0-255]! value was {page}')
+        self._page = page
+
+    @property
+    def lastPage(self) -> int:
+        return self._lastPage
+
+    @lastPage.setter
+    def lastPage(self, lastPage: int):
+        if type(lastPage) is not int:
+            raise TypeError(f'lastPage must be an integer! Type was {type(lastPage)}')
+        if lastPage not in range(0, 256):
+            raise ValueError(f'lastPage is a byte! values: [0-255]! value was {lastPage}')
+        self._lastPage = lastPage
+
+    @property
+    def universes(self) -> tuple:
+        return tuple(self._universes)
+
+    @universes.setter
+    def universes(self, universes: tuple):
+        if len(universes) > 512 or \
+                not all((isinstance(x, int) and (0 <= x <= 63999)) for x in universes):
+            raise ValueError(f'Universes is a tuple with a max length of 512! The data in the tuple has to be valid universe numbers! '
+                             f'Length was {len(universes)}')
+        self._universes = sorted(universes)
+        self.length = 120 + (len(universes) * 2)  # generate new length value for the packet
+
+    def getBytes(self) -> list:
+        rtrnList = super().getBytes()
+        # Flags and Length Framing Layer:--------------------
+        rtrnList.extend(make_flagsandlength(self.length - 38))
+        # Vector Framing Layer:------------------------------
+        rtrnList.extend(VECTOR_E131_EXTENDED_DISCOVERY)
+        # source Name Framing Layer:-------------------------
+        # sourceName:---------------------------
+        # UTF-8 encode the string
+        tmpSourceName = str(self._sourceName).encode('UTF-8')
+        rtrnList.extend(tmpSourceName)
+        # pad to 64 bytes
+        rtrnList.extend([0] * (64 - len(tmpSourceName)))
+        # reserved fields:-----------------------------------
+        rtrnList.extend([0] * 4)
+        # Universe Discovery Layer:-------------------------------------
+        # Flags and Length:----------------------------------
+        rtrnList.extend(make_flagsandlength(self.length - 112))
+        # Vector UDL:----------------------------------------
+        rtrnList.extend(VECTOR_UNIVERSE_DISCOVERY_UNIVERSE_LIST)
+        # page:----------------------------------------------
+        rtrnList.append(self._page & 0xFF)
+        # last page:-----------------------------------------
+        rtrnList.append(self._lastPage & 0xFF)
+        # universes:-----------------------------------------
+        for universe in self._universes:  # universe is a 16-bit number!
+            rtrnList.extend(int_to_bytes(universe))
+
+        return rtrnList
+
+    @staticmethod
+    def make_universe_discovery_packet(raw_data) -> 'UniverseDiscoveryPacket':
+        # Check if the length is sufficient
+        if len(raw_data) < 120:
+            raise TypeError('The length of the provided data is not long enough! Min length is 120!')
+        # Check if the three Vectors are correct
+        # REMEMBER: when slicing: [inclusive:exclusive]
+        if tuple(raw_data[18:22]) != tuple(VECTOR_ROOT_E131_EXTENDED) or \
+           tuple(raw_data[40:44]) != tuple(VECTOR_E131_EXTENDED_DISCOVERY) or \
+           tuple(raw_data[114:118]) != tuple(VECTOR_UNIVERSE_DISCOVERY_UNIVERSE_LIST):
+            raise TypeError('Some of the vectors in the given raw data are not compatible to the E131 Standard!')
+
+        # tricky part: convert plain bytes to a useful list of 16-bit values for further use
+        # Problem: the given raw_byte can be longer than the dynamic length of the list of universes
+        # first: extract the length from the Universe Discovery Layer (UDL)
+        length = (byte_tuple_to_int((raw_data[112], raw_data[113])) & 0xFFF) - 8
+        # remember: UDL has 8 bytes plus the universes
+        # remember: Flags and length includes a 12-bit length field
+        universes = convert_raw_data_to_universes(raw_data[120:120 + length])
+        tmpPacket = UniverseDiscoveryPacket(cid=tuple(raw_data[22:38]), sourceName=bytes(raw_data[44:108]).decode('utf-8').replace('\0', ''),
+                                            universes=universes)
+        tmpPacket._page = raw_data[118]
+        tmpPacket._lastPage = raw_data[119]
+        return tmpPacket
+
+    @staticmethod
+    def make_multiple_uni_disc_packets(cid: tuple, sourceName: str, universes: list) -> List['UniverseDiscoveryPacket']:
+        """
+        Creates a list with universe discovery packets based on the given data. It creates automatically enough packets
+        for the given universes list.
+        :param cid: the cid to use in all packets
+        :param sourceName: the source name to use in all packets
+        :param universes: the universes. Can be longer than 512, but has to be shorter than 256*512.
+        The values in the list should be [1-63999]
+        :return: a list full of universe discovery packets
+        """
+        tmpList = []
+        # divide len(universes) with 512 and round up; // is integer division
+        num_of_packets = (len(universes) + 512 - 1) // 512
+        universes.sort()  # E1.31 wants that the send out universes are sorted
+        for i in range(0, num_of_packets):
+            if i == num_of_packets - 1:
+                tmpUniverses = universes[i * 512:len(universes)]
+                # if we are here, then the for is in the last loop
+            else:
+                tmpUniverses = universes[i * 512:(i + 1) * 512]
+            # create new UniverseDiscoveryPacket and append it to the list. Page and lastPage are getting special values
+            tmpList.append(UniverseDiscoveryPacket(cid=cid, sourceName=sourceName, universes=tmpUniverses,
+                                                   page=i, lastPage=num_of_packets - 1))
+        return tmpList
+
+
+def convert_raw_data_to_universes(raw_data) -> tuple:
+    """
+    converts the raw data to a readable universes tuple. The raw_data is scanned from index 0 and has to have
+    16-bit numbers with high byte first. The data is converted from the start to the beginning!
+    :param raw_data: the raw data to convert
+    :return: tuple full with 16-bit numbers
+    """
+    if len(raw_data) % 2 != 0:
+        raise TypeError('The given data does not have an even number of elements!')
+    rtrnList = []
+    for i in range(0, len(raw_data), 2):
+        rtrnList.append(byte_tuple_to_int((raw_data[i], raw_data[i + 1])))
+    return tuple(rtrnList)

--- a/sacn/messages/universe_discovery_test.py
+++ b/sacn/messages/universe_discovery_test.py
@@ -1,0 +1,213 @@
+# This file is under MIT license. The license file can be obtained in the root directory of this module.
+
+import pytest
+from dmx.sacn.messages.universe_discovery import UniverseDiscoveryPacket
+from dmx.sacn.messages.general_test import property_number_range_check
+
+
+def test_constructor():
+    # positive tests
+    cid = tuple(range(0, 16))
+    sourceName = 'Test'
+    universes = tuple(range(0, 512))
+    page = 0
+    lastPage = 1
+    packet = UniverseDiscoveryPacket(cid, sourceName, universes, page, lastPage)
+    assert packet.length == 120 + (2 * len(universes))
+    assert packet.cid == cid
+    assert packet.sourceName == sourceName
+    assert packet.universes == universes
+    assert packet.page == page
+    assert packet.lastPage == lastPage
+    # using wrong values for CID
+    with pytest.raises(ValueError):
+        UniverseDiscoveryPacket(tuple(range(0, 17)), sourceName, universes)
+
+
+def test_sourceName():
+    # test string has 25 characters but is 64 bytes (1 too many) when UTF-8 encoded
+    overlength_string = "𔑑覱֪I𤵎⠣Ķ'𫳪爓Û:𢏴㓑ò4𰬀鿹џ>𖬲膬ЩJ𞄇"
+    packet = UniverseDiscoveryPacket(tuple(range(0, 16)), 'Test', ())
+    # test property setter
+    with pytest.raises(TypeError):
+        packet.sourceName = 0x33
+    with pytest.raises(ValueError):
+        packet.sourceName = overlength_string
+    # test constructor
+    with pytest.raises(ValueError):
+        packet = UniverseDiscoveryPacket(tuple(range(0, 16)), overlength_string, ())
+
+
+def test_page():
+    packet = UniverseDiscoveryPacket(tuple(range(0, 16)), 'Test', ())
+    # test property setter
+    def property(i): packet.page = i
+    # test constructor for the same parameter
+    def constructor(i): UniverseDiscoveryPacket(tuple(range(0, 16)), 'Test', (), i)
+    property_number_range_check(0, 255, property, constructor)
+
+
+def test_last_page():
+    packet = UniverseDiscoveryPacket(tuple(range(0, 16)), 'Test', ())
+    # test property setter
+    def property(i): packet.lastPage = i
+    # test constructor for the same parameter
+    def constructor(i): UniverseDiscoveryPacket(tuple(range(0, 16)), 'Test', (), 0, i)
+    property_number_range_check(0, 255, property, constructor)
+
+
+def test_universes():
+    packet = UniverseDiscoveryPacket(tuple(range(0, 16)), 'Test', ())
+
+    def execute_universes_expect(universes: tuple):
+        with pytest.raises(ValueError):
+            packet.universes = universes
+        with pytest.raises(ValueError):
+            UniverseDiscoveryPacket(tuple(range(0, 16)), 'Test', universes)
+
+    # test valid lengths
+    for i in range(1, 513):
+        universes = tuple(range(0, i))
+        # test property setter
+        packet.universes = universes
+        assert packet.length == 120 + (2 * len(universes))
+        # test constructor for the same parameter
+        UniverseDiscoveryPacket(tuple(range(0, 16)), 'Test', universes)
+
+    # test that the universes list is sorted
+    packet.universes = (3, 1, 2)
+    assert packet.universes == (1, 2, 3)
+
+    # test for non-int and out of range values values in tuple
+    execute_universes_expect(tuple('string'))
+    execute_universes_expect(tuple(range(64000, 65000)))
+
+    # test for tuple-length > 512
+    execute_universes_expect(tuple(range(0, 513)))
+
+
+def test_make_multiple_uni_disc_packets():
+    # test with a list that spawns three packets
+    universes = list(range(0, 1026))
+    packets = UniverseDiscoveryPacket.make_multiple_uni_disc_packets(tuple(range(0, 16)), 'Test', universes)
+    assert len(packets) == 3
+    assert packets[0].universes == tuple(range(0, 512))
+    assert packets[1].universes == tuple(range(512, 1024))
+    assert packets[2].universes == tuple(range(1024, 1026))
+    assert packets[0].page == 0
+    assert packets[1].page == 1
+    assert packets[2].page == 2
+    assert packets[0].lastPage == 2
+    assert packets[1].lastPage == 2
+    assert packets[2].lastPage == 2
+    # test with a list that spawns one packet
+    universes = list(range(0, 2))
+    packets = UniverseDiscoveryPacket.make_multiple_uni_disc_packets(tuple(range(0, 16)), 'Test', universes)
+    assert len(packets) == 1
+    assert packets[0].universes == tuple(universes)
+    assert packets[0].page == 0
+    assert packets[0].lastPage == 0
+
+
+def test_get_bytes():
+    cid = (0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e)
+    packet = UniverseDiscoveryPacket(cid, 'Source_A', (1, 2, 3), 0, 1)
+    assert packet.getBytes() == [
+        # preamble size
+        0x00, 0x10,
+        # postamble size
+        0x00, 0x00,
+        # ACN packet identifier
+        0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
+        # flags and length
+        0x70, 0x6e,
+        # Root vector
+        0x00, 0x00, 0x00, 0x08,
+        # CID
+        0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
+        # Framing flags and length
+        0x70, 0x58,
+        # Framing vector
+        0x00, 0x00, 0x00, 0x02,
+        # Source name 'Source_A'
+        0x53, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x5f, 0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        # reserved
+        0x00, 0x00, 0x00, 0x00,
+        # universe discovery layer - flags and length
+        0x70, 0x0e,
+        # vector
+        0x00, 0x00, 0x00, 0x01,
+        # page
+        0x00,
+        # last page
+        0x01,
+        # universes as 16-bit integers
+        0x00, 0x01, 0x00, 0x02, 0x00, 0x03,
+    ]
+
+
+def test_parse_sync_packet():
+    raw_data = [
+        # preamble size
+        0x00, 0x10,
+        # postamble size
+        0x00, 0x00,
+        # ACN packet identifier
+        0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00,
+        # flags and length
+        0x70, 0x6e,
+        # Root vector
+        0x00, 0x00, 0x00, 0x08,
+        # CID
+        0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e,
+        # Framing flags and length
+        0x70, 0x58,
+        # Framing vector
+        0x00, 0x00, 0x00, 0x02,
+        # Source name 'Source_A'
+        0x53, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x5f, 0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        # reserved
+        0x00, 0x00, 0x00, 0x00,
+        # universe discovery layer - flags and length
+        0x70, 0x0e,
+        # vector
+        0x00, 0x00, 0x00, 0x01,
+        # page
+        0x00,
+        # last page
+        0x01,
+        # universes as 16-bit integers
+        0x00, 0x01, 0x00, 0x02, 0x00, 0x03,
+    ]
+    packet = UniverseDiscoveryPacket.make_universe_discovery_packet(raw_data)
+    assert packet.length == 126
+    assert packet.cid == (0xef, 0x07, 0xc8, 0xdd, 0x00, 0x64, 0x44, 0x01, 0xa3, 0xa2, 0x45, 0x9e, 0xf8, 0xe6, 0x14, 0x3e)
+    assert packet.sourceName == 'Source_A'
+    assert packet.page == 0
+    assert packet.lastPage == 1
+    assert packet.universes == (1, 2, 3)
+
+    # test for invalid data
+    # test for too short data arrays
+    for i in range(1, 120):
+        with pytest.raises(TypeError):
+            UniverseDiscoveryPacket.make_universe_discovery_packet([x % 256 for x in range(0, i)])
+    # test for invalid vectors
+    with pytest.raises(TypeError):
+        UniverseDiscoveryPacket.make_universe_discovery_packet([x % 256 for x in range(0, 126)])
+    # test for odd universes list length
+    raw_data = raw_data[0:len(raw_data) - 1]
+    with pytest.raises(TypeError):
+        UniverseDiscoveryPacket.make_universe_discovery_packet(raw_data)
+
+
+def test_byte_construction_and_deconstruction():
+    built_packet = UniverseDiscoveryPacket(tuple(range(0, 16)), 'Test', tuple(range(0, 512)), 0, 1)
+    read_packet = UniverseDiscoveryPacket.make_universe_discovery_packet(built_packet.getBytes())
+    assert built_packet == read_packet

--- a/sacn/receiver.py
+++ b/sacn/receiver.py
@@ -1,0 +1,145 @@
+# This file is under MIT license. The license file can be obtained in the root directory of this module.
+
+from dmx.sacn.messages.data_packet import DataPacket, calculate_multicast_addr
+from dmx.sacn.receiving.receiver_handler import ReceiverHandler, ReceiverHandlerListener
+from dmx.sacn.receiving.receiver_socket_base import ReceiverSocketBase
+from typing import Tuple
+
+LISTEN_ON_OPTIONS = ('availability', 'universe')
+
+
+class sACNreceiver(ReceiverHandlerListener):
+    def __init__(self, bind_address: str = '0.0.0.0', bind_port: int = 5568, socket: ReceiverSocketBase = None):
+        """
+        Make a receiver for sACN data. Do not forget to start and add callbacks for receiving messages!
+        :param bind_address: if you are on a Windows system and want to use multicast provide a valid interface
+        IP-Address! Otherwise omit.
+        :param bind_port: Default: 5568. It is not recommended to change this value!
+        Only use when you know what you are doing!
+        :param socket: Provide a special socket implementation if necessary. Must be derived from ReceiverSocketBase,
+        only use if the default socket implementation of this library is not sufficient.
+        """
+
+        self._callbacks: dict = {}
+        self._handler: ReceiverHandler = ReceiverHandler(bind_address, bind_port, self, socket)
+
+    def on_availability_change(self, universe: int, changed: str) -> None:
+        callbacks = []
+        # call nothing, if the list with callbacks is empty
+        try:
+            callbacks = self._callbacks[LISTEN_ON_OPTIONS[0]]
+        except KeyError:
+            pass
+        for callback in callbacks:
+            # fire callbacks if this is the first received packet for this universe
+            callback(universe=universe, changed=changed)
+
+    def on_dmx_data_change(self, packet: DataPacket) -> None:
+        callbacks = []
+        # call nothing, if the list with callbacks is empty
+        try:
+            callbacks = self._callbacks[packet.universe]
+        except KeyError:
+            pass
+        for callback in callbacks:
+            callback(packet)
+
+    def listen_on(self, trigger: str, **kwargs) -> callable:
+        """
+        This is a simple decorator for registering a callback for an event. You can also use 'register_listener'.
+        A list with all possible options is available via LISTEN_ON_OPTIONS.
+        :param trigger: Currently supported options: 'availability', 'universe'
+        """
+        def decorator(f):
+            self.register_listener(trigger, f, **kwargs)
+            return f
+        return decorator
+
+    def register_listener(self, trigger: str, func: callable, **kwargs) -> None:
+        """
+        Register a listener for the given trigger. Raises an TypeError when the trigger is not a valid one.
+        To get a list with all valid triggers, use LISTEN_ON_OPTIONS.
+        :param trigger: the trigger on which the given callback should be used.
+        Currently supported: 'availability', 'universe'
+        :param func: the callback. The parameters depend on the trigger. See README for more information
+        """
+        if trigger in LISTEN_ON_OPTIONS:
+            if trigger == LISTEN_ON_OPTIONS[1]:  # if the trigger is universe, use the universe from args as key
+                universe = kwargs[LISTEN_ON_OPTIONS[1]]
+                try:
+                    self._callbacks[universe].append(func)
+                except KeyError:
+                    self._callbacks[universe] = [func]
+            try:
+                self._callbacks[trigger].append(func)
+            except KeyError:
+                self._callbacks[trigger] = [func]
+        else:
+            raise TypeError(f'The given trigger "{trigger}" is not a valid one!')
+
+    def remove_listener(self, func: callable) -> None:
+        """
+        Removes the given function from all listening options (see LISTEN_ON_OPTIONS).
+        If the function never was registered, nothing happens. Note: if a function was registered multiple times,
+        this remove function needs to be called only once.
+        :param func: the callback
+        """
+        for _trigger, listeners in self._callbacks.items():
+            while True:
+                try:
+                    listeners.remove(func)
+                except ValueError:
+                    break
+
+    def remove_listener_from_universe(self, universe: int) -> None:
+        """
+        Removes all listeners from the given universe. This does only have effect on the 'universe' listening trigger.
+        If no function was registered for this universe, nothing happens.
+        :param universe: the universe to clear
+        """
+        self._callbacks.pop(universe, None)
+
+    def join_multicast(self, universe: int) -> None:
+        """
+        Joins the multicast address that is used for the given universe. Note: If you are on Windows you must have given
+        a bind IP-Address for this feature to function properly. On the other hand you are not allowed to set a bind
+        address if you are on any other OS.
+        :param universe: the universe to join the multicast group.
+        The network hardware has to support the multicast feature!
+        """
+        self._handler.socket.join_multicast(calculate_multicast_addr(universe))
+
+    def leave_multicast(self, universe: int) -> None:
+        """
+        Try to leave the multicast group with the specified universe. This does not throw any exception if the group
+        could not be leaved.
+        :param universe: the universe to leave the multicast group.
+        The network hardware has to support the multicast feature!
+        """
+        self._handler.socket.leave_multicast(calculate_multicast_addr(universe))
+
+    def start(self) -> None:
+        """
+        Starts a new thread that handles the input. If a thread is already running, the thread will be restarted.
+        """
+        self.stop()  # stop an existing thread
+        self._handler.socket.start()
+
+    def stop(self) -> None:
+        """
+        Stops a running thread and closes the underlying socket. If no thread was started, nothing happens.
+        Do not reuse the socket after calling stop once.
+        """
+        self._handler.socket.stop()
+
+    def get_possible_universes(self) -> Tuple[int]:
+        """
+        Get all universes that are possible because a data packet was received. Timeouted data is removed from the list,
+        so the list may change over time. Depending on sources that are shutting down their streams.
+        :return: a tuple with all universes that were received so far and hadn't a timeout
+        """
+        return tuple(self._handler.get_possible_universes())
+
+    def __del__(self):
+        # stop a potential running thread
+        self.stop()

--- a/sacn/receiver_test.py
+++ b/sacn/receiver_test.py
@@ -1,0 +1,221 @@
+# This file is under MIT license. The license file can be obtained in the root directory of this module.
+
+import pytest
+import sacn
+from sacn.messages.data_packet import DataPacket
+from sacn.receiving.receiver_socket_test import ReceiverSocketTest
+
+
+def get_receiver():
+    socket = ReceiverSocketTest()
+    receiver = sacn.sACNreceiver(socket=socket)
+    # wire up for unit test
+    receiver._handler.socket._listener = receiver._handler
+    return receiver, socket
+
+
+def test_constructor():
+    receiver, _ = get_receiver()
+    assert receiver._callbacks is not None
+    assert receiver._handler is not None
+
+
+def test_listen_on_availability_change():
+    receiver, socket = get_receiver()
+
+    called = False
+
+    @receiver.listen_on('availability')
+    def callback_available(universe, changed):
+        assert changed == 'available'
+        assert universe == 1
+        nonlocal called
+        called = True
+
+    packet = DataPacket(
+        cid=tuple(range(0, 16)),
+        sourceName='Test',
+        universe=1,
+        dmxData=tuple(range(0, 16))
+    )
+    socket.call_on_data(bytes(packet.getBytes()), 0)
+    assert called
+
+
+def test_listen_on_dmx_data_change():
+    receiver, socket = get_receiver()
+
+    packetSend = DataPacket(
+        cid=tuple(range(0, 16)),
+        sourceName='Test',
+        universe=1,
+        dmxData=tuple(range(0, 16))
+    )
+
+    called = False
+
+    @receiver.listen_on('universe', universe=packetSend.universe)
+    def callback_packet(packet):
+        assert packetSend.__dict__ == packet.__dict__
+        nonlocal called
+        called = True
+
+    socket.call_on_data(bytes(packetSend.getBytes()), 0)
+    assert called
+
+
+def test_remove_listener():
+    receiver, socket = get_receiver()
+
+    packetSend = DataPacket(
+        cid=tuple(range(0, 16)),
+        sourceName='Test',
+        universe=1,
+        dmxData=tuple(range(0, 16))
+    )
+
+    called = 0
+
+    def callback_packet(packet):
+        assert packetSend.__dict__ == packet.__dict__
+        nonlocal called
+        called += 1
+
+    # register listener multiple times
+    receiver.register_listener('universe', callback_packet, universe=packetSend.universe)
+    receiver.register_listener('universe', callback_packet, universe=packetSend.universe)
+
+    socket.call_on_data(bytes(packetSend.getBytes()), 0)
+    assert called == 2
+
+    # change DMX data to trigger a change
+    packetSend.dmxData = tuple(range(16, 32))
+    packetSend.sequence_increase()
+
+    receiver.remove_listener(callback_packet)
+
+    # removing a listener does not exist, should do nothing
+    receiver.remove_listener(None)
+
+    socket.call_on_data(bytes(packetSend.getBytes()), 0)
+    assert called == 2
+
+
+def test_remove_listener_from_universe():
+    receiver, socket = get_receiver()
+
+    test_universe_one = 1
+    test_universe_two = 2
+
+    packet_send = DataPacket(
+        cid=tuple(range(0, 16)),
+        sourceName='Test',
+        universe=test_universe_one,
+        dmxData=tuple(range(0, 16))
+    )
+
+    called = 0
+
+    def callback_packet(packet):
+        assert packet_send.__dict__ == packet.__dict__
+        nonlocal called
+        called += 1
+
+    # register listener multiple times
+    receiver.register_listener('universe', callback_packet, universe=test_universe_one)
+    receiver.register_listener('universe', callback_packet, universe=test_universe_two)
+
+    packet_send.universe = test_universe_one
+    socket.call_on_data(bytes(packet_send.getBytes()), 0)
+    assert called == 1
+    packet_send.universe = test_universe_two
+    socket.call_on_data(bytes(packet_send.getBytes()), 0)
+    assert called == 2
+
+    # change DMX data to trigger a change
+    packet_send.dmxData = tuple(range(16, 32))
+    packet_send.sequence_increase()
+
+    test_universe_removed = test_universe_one
+    receiver.remove_listener_from_universe(test_universe_removed)
+
+    # removing from a universe that does not exist, should do nothing
+    receiver.remove_listener_from_universe(12345)
+
+    # call to the removed universe should not happen
+    packet_send.universe = test_universe_removed
+    socket.call_on_data(bytes(packet_send.getBytes()), 0)
+    assert called == 2
+    # other universes should not be affected
+    packet_send.universe = test_universe_two
+    socket.call_on_data(bytes(packet_send.getBytes()), 0)
+    assert called == 3
+
+
+def test_invalid_listener():
+    receiver, socket = get_receiver()
+
+    with pytest.raises(TypeError):
+        @receiver.listen_on('test')
+        def callback():
+            pass
+
+
+def test_possible_universes():
+    receiver, socket = get_receiver()
+
+    assert receiver.get_possible_universes() == ()
+    packet = DataPacket(
+        cid=tuple(range(0, 16)),
+        sourceName='Test',
+        universe=1,
+        dmxData=tuple(range(0, 16))
+    )
+    socket.call_on_data(bytes(packet.getBytes()), 0)
+    assert receiver.get_possible_universes() == tuple([1])
+
+
+def test_join_multicast():
+    receiver, socket = get_receiver()
+
+    assert socket.join_multicast_called is None
+    receiver.join_multicast(1)
+    assert socket.join_multicast_called == '239.255.0.1'
+
+    with pytest.raises(TypeError):
+        receiver.join_multicast('test')
+
+
+def test_leave_multicast():
+    receiver, socket = get_receiver()
+
+    assert socket.leave_multicast_called is None
+    receiver.leave_multicast(1)
+    assert socket.leave_multicast_called == '239.255.0.1'
+
+    with pytest.raises(TypeError):
+        receiver.leave_multicast('test')
+
+
+def test_start():
+    receiver, socket = get_receiver()
+
+    assert socket.start_called is False
+    receiver.start()
+    assert socket.start_called is True
+
+
+def test_stop():
+    receiver, socket = get_receiver()
+
+    assert socket.stop_called is False
+    receiver.stop()
+    assert socket.stop_called is True
+
+
+def test_stop_destructor():
+    receiver, socket = get_receiver()
+
+    assert socket.stop_called is False
+    receiver.__del__()
+    assert socket.stop_called is True

--- a/sacn/receiving/receiver_handler.py
+++ b/sacn/receiving/receiver_handler.py
@@ -1,0 +1,154 @@
+# This file is under MIT license. The license file can be obtained in the root directory of this module.
+
+from typing import Dict, List
+
+from dmx.sacn.messages.data_packet import DataPacket
+from dmx.sacn.receiving.receiver_socket_base import ReceiverSocketBase, ReceiverSocketListener
+from dmx.sacn.receiving.receiver_socket_udp import ReceiverSocketUDP
+
+E131_NETWORK_DATA_LOSS_TIMEOUT_ms = 2500
+
+
+class ReceiverHandlerListener:
+    """
+    Listener interface that defines methods for listening on changes on the ReceiverHandler.
+    """
+
+    def on_availability_change(self, universe: int, changed: str) -> None:
+        raise NotImplementedError
+
+    def on_dmx_data_change(self, packet: DataPacket) -> None:
+        raise NotImplementedError
+
+
+class ReceiverHandler(ReceiverSocketListener):
+    def __init__(self, bind_address: str, bind_port: int, listener: ReceiverHandlerListener, socket: ReceiverSocketBase = None):
+        """
+        This is a private class and should not be used elsewhere. It handles the receiver state with sACN specific values.
+        Calls any changes in the data streams on the listener.
+        Uses a UDP receiver socket with the given bind-address and -port, if the socket was not provided (i.e. None).
+        """
+        if socket is None:
+            self.socket: ReceiverSocketBase = ReceiverSocketUDP(self, bind_address, bind_port)
+        else:
+            self.socket: ReceiverSocketBase = socket
+        self._listener: ReceiverHandlerListener = listener
+        # previousData for storing the last data that was send in a universe to check if the data has changed
+        self._previousData: Dict[int, tuple] = {}
+        # priorities are stored here. This is for checking if the incoming data has the best priority.
+        # universes are the keys and
+        # the value is a tuple with the last priority and the time when this priority recently was received
+        self._priorities: Dict[int, tuple] = {}
+        # store the last timestamp when something on an universe arrived for checking for timeouts
+        self._lastDataTimestamps: Dict[int, float] = {}
+        # store the last sequence number of a universe here:
+        self._lastSequence: Dict[int, int] = {}
+
+    def on_data(self, data: bytes, current_time: float) -> None:
+        try:
+            tmp_packet = DataPacket.make_data_packet(data)
+        except TypeError:  # try to make a DataPacket. If it fails just ignore it
+            return
+
+        self.check_for_stream_terminated_and_refresh_timestamp(tmp_packet, current_time)
+        self.refresh_priorities(tmp_packet, current_time)
+        if not self.is_legal_priority(tmp_packet):
+            return
+        if not self.is_legal_sequence(tmp_packet):  # check for bad sequence number
+            return
+        self.fire_callbacks_universe(tmp_packet)
+
+    def on_periodic_callback(self, current_time: float) -> None:
+        # check all DataTimestamps for timeouts
+        for key, value in list(self._lastDataTimestamps.items()):
+            #  this is converted to list, because the length of the dict changes
+            if check_timeout(current_time, value):
+                self.fire_timeout_callback_and_delete(key)
+
+    def check_for_stream_terminated_and_refresh_timestamp(self, packet: DataPacket, current_time: float) -> None:
+        # refresh the last timestamp on a universe, but check if its the last message of a stream
+        # (the stream is terminated by the Stream termination bit)
+        if packet.option_StreamTerminated:
+            self.fire_timeout_callback_and_delete(packet.universe)
+        else:
+            # check if we add or refresh the data in lastDataTimestamps
+            if packet.universe not in self._lastDataTimestamps.keys():
+                # fire callbacks if this is the first received packet for this universe
+                self._listener.on_availability_change(universe=packet.universe, changed='available')
+            self._lastDataTimestamps[packet.universe] = current_time
+
+    def fire_timeout_callback_and_delete(self, universe: int):
+        self._listener.on_availability_change(universe=universe, changed='timeout')
+        # delete the timestamp so that the callback is not fired multiple times
+        try:
+            del self._lastDataTimestamps[universe]
+        except KeyError:
+            pass  # drop exception, if there was no last timestamp
+        # delete sequence entries so that no packet out of order problems occur
+        try:
+            del self._lastSequence[universe]
+        except KeyError:
+            pass  # drop exception, if there was no last sequence number
+
+    def refresh_priorities(self, packet: DataPacket, current_time: float) -> None:
+        # check the priority and refresh the priorities dict
+        # check if the stored priority has timeouted and make the current packets priority the new one
+        if packet.universe not in self._priorities.keys() or \
+           self._priorities[packet.universe] is None or \
+           check_timeout(current_time, self._priorities[packet.universe][1]) or \
+           self._priorities[packet.universe][0] <= packet.priority:  # if the send priority is higher or
+            # equal than the stored one, than make the priority the new one
+            self._priorities[packet.universe] = (packet.priority, current_time)
+
+    def is_legal_sequence(self, packet: DataPacket) -> bool:
+        """
+        Check if the Sequence number of the DataPacket is legal.
+        For more information see page 17 of http://tsp.esta.org/tsp/documents/docs/E1-31-2016.pdf.
+        :param packet: the packet to check
+        :return: true if the sequence is legal. False if the sequence number is bad
+        """
+        # if the sequence of the packet is smaller than the last received sequence, return false
+        # therefore calculate the difference between the two values:
+        try:  # try, because self.lastSequence might not been initialized
+            diff = packet.sequence - self._lastSequence[packet.universe]
+            # if diff is between ]-20,0], return False for a bad packet sequence
+            if diff <= 0 and diff > -20:
+                return False
+        except KeyError:
+            pass
+        # if the sequence is good, return True and refresh the list with the new value
+        self._lastSequence[packet.universe] = packet.sequence
+        return True
+
+    def is_legal_priority(self, packet: DataPacket):
+        """
+        Check if the given packet has high enough priority for the stored values for the packet's universe.
+        :param packet: the packet to check
+        :return: returns True if the priority is good. Otherwise False
+        """
+        # check if the packet's priority is high enough to get processed
+        if packet.priority < self._priorities[packet.universe][0]:
+            return False  # return if the universe is not interesting
+        else:
+            return True
+
+    def fire_callbacks_universe(self, packet: DataPacket) -> None:
+        # call the listeners for the universe but before check if the data has changed
+        # check if there are listeners for the universe before proceeding
+        if packet.universe not in self._previousData.keys() or \
+           self._previousData[packet.universe] is None or \
+           self._previousData[packet.universe] != packet.dmxData:
+            # set previous data and inherit callbacks
+            self._previousData[packet.universe] = packet.dmxData
+            self._listener.on_dmx_data_change(packet)
+
+    def get_possible_universes(self) -> List[int]:
+        return list(self._lastDataTimestamps.keys())
+
+
+def time_millis(current_time: float) -> int:
+    return int(round(current_time * 1000))
+
+
+def check_timeout(current_time: float, time: float) -> bool:
+    return abs(time_millis(current_time) - time_millis(time)) > E131_NETWORK_DATA_LOSS_TIMEOUT_ms

--- a/sacn/receiving/receiver_handler_test.py
+++ b/sacn/receiving/receiver_handler_test.py
@@ -1,0 +1,225 @@
+# This file is under MIT license. The license file can be obtained in the root directory of this module.
+
+import pytest
+from dmx.sacn.messages.data_packet import DataPacket
+from dmx.sacn.receiving.receiver_handler import ReceiverHandler, ReceiverHandlerListener, E131_NETWORK_DATA_LOSS_TIMEOUT_ms
+from dmx.sacn.receiving.receiver_socket_test import ReceiverSocketTest
+
+
+class ReceiverHandlerListenerTest(ReceiverHandlerListener):
+    def __init__(self):
+        self.on_availability_change_universe: int = None
+        self.on_availability_change_changed: str = None
+        self.on_dmx_data_change_packet: DataPacket = None
+
+    def on_availability_change(self, universe: int, changed: str) -> None:
+        self.on_availability_change_universe = universe
+        self.on_availability_change_changed = changed
+
+    def on_dmx_data_change(self, packet: DataPacket) -> None:
+        self.on_dmx_data_change_packet = packet
+
+
+def get_handler():
+    bind_address = 'Test'
+    bind_port = 1234
+    listener = ReceiverHandlerListenerTest()
+    socket = ReceiverSocketTest()
+    handler = ReceiverHandler(bind_address, bind_port, listener, socket)
+    # wire up for unit test
+    socket._listener = handler
+    return handler, listener, socket
+
+
+def test_constructor():
+    handler, _, _ = get_handler()
+    assert handler._listener is not None
+    assert handler._previousData is not None
+    assert handler._priorities is not None
+    assert handler._lastDataTimestamps is not None
+    assert handler._lastSequence is not None
+
+
+def test_first_packet():
+    _, listener, socket = get_handler()
+    assert listener.on_availability_change_changed is None
+    assert listener.on_availability_change_universe is None
+    assert listener.on_dmx_data_change_packet is None
+    packet = DataPacket(
+        cid=tuple(range(0, 16)),
+        sourceName='Test',
+        universe=1,
+        dmxData=tuple(range(0, 16))
+    )
+    socket.call_on_data(bytes(packet.getBytes()), 0)
+    assert listener.on_availability_change_changed == 'available'
+    assert listener.on_availability_change_universe == 1
+    assert listener.on_dmx_data_change_packet.__dict__ == packet.__dict__
+
+
+def test_first_packet_stream_terminated():
+    _, listener, socket = get_handler()
+    assert listener.on_availability_change_changed is None
+    assert listener.on_availability_change_universe is None
+    assert listener.on_dmx_data_change_packet is None
+    packet = DataPacket(
+        cid=tuple(range(0, 16)),
+        sourceName='Test',
+        universe=1,
+        dmxData=tuple(range(0, 16)),
+        streamTerminated=True
+    )
+    socket.call_on_data(bytes(packet.getBytes()), 0)
+    assert listener.on_availability_change_changed == 'timeout'
+    assert listener.on_availability_change_universe == 1
+    assert listener.on_dmx_data_change_packet.__dict__ == packet.__dict__
+
+
+def test_invalid_packet_bytes():
+    _, listener, socket = get_handler()
+    assert listener.on_availability_change_changed is None
+    assert listener.on_availability_change_universe is None
+    assert listener.on_dmx_data_change_packet is None
+    # provide 'random' data that is no DataPacket
+    socket.call_on_data(bytes(x % 256 for x in range(0, 512)), 0)
+    assert listener.on_availability_change_changed is None
+    assert listener.on_availability_change_universe is None
+    assert listener.on_dmx_data_change_packet is None
+
+
+def test_invalid_priority():
+    # send a lower priority on a second packet
+    _, listener, socket = get_handler()
+    assert listener.on_dmx_data_change_packet is None
+    packet1 = DataPacket(
+        cid=tuple(range(0, 16)),
+        sourceName='Test',
+        universe=1,
+        dmxData=tuple(range(0, 16)),
+        priority=100
+    )
+    socket.call_on_data(bytes(packet1.getBytes()), 0)
+    assert listener.on_dmx_data_change_packet.__dict__ == packet1.__dict__
+    packet2 = DataPacket(
+        cid=tuple(range(0, 16)),
+        sourceName='Test',
+        universe=1,
+        dmxData=tuple(range(0, 16)),
+        priority=99
+    )
+    socket.call_on_data(bytes(packet2.getBytes()), 1)
+    # second packet does not override the previous one
+    assert listener.on_dmx_data_change_packet.__dict__ == packet1.__dict__
+
+
+def test_invalid_sequence():
+    # send a lower sequence on a second packet
+    def case_goes_through(sequence_a: int, sequence_b: int):
+        _, listener, socket = get_handler()
+        assert listener.on_dmx_data_change_packet is None
+        packet1 = DataPacket(
+            cid=tuple(range(0, 16)),
+            sourceName='Test',
+            universe=1,
+            dmxData=tuple(range(0, 16)),
+            sequence=sequence_a
+        )
+        socket.call_on_data(bytes(packet1.getBytes()), 0)
+        assert listener.on_dmx_data_change_packet.__dict__ == packet1.__dict__
+        packet2 = DataPacket(
+            cid=tuple(range(0, 16)),
+            sourceName='Test',
+            universe=1,
+            # change DMX data to simulate data from another source
+            dmxData=tuple(range(1, 17)),
+            sequence=sequence_b
+        )
+        socket.call_on_data(bytes(packet2.getBytes()), 1)
+        assert listener.on_dmx_data_change_packet.__dict__ == packet2.__dict__
+
+    case_goes_through(100, 80)
+    case_goes_through(101, 102)
+    case_goes_through(255, 0)
+    case_goes_through(0, 236)
+    with pytest.raises(AssertionError):
+        case_goes_through(100, 81)
+    with pytest.raises(AssertionError):
+        case_goes_through(100, 99)
+    # Note: this should probably also fail, but the algorithm from the E1.31 spec does not
+    # work with wrap around 255...
+    case_goes_through(0, 255)
+
+
+def test_possible_universes():
+    handler, _, socket = get_handler()
+    assert handler.get_possible_universes() == []
+    packet = DataPacket(
+        cid=tuple(range(0, 16)),
+        sourceName='Test',
+        universe=1,
+        dmxData=tuple(range(0, 16))
+    )
+    # add universe 1
+    socket.call_on_data(bytes(packet.getBytes()), 0)
+    assert handler.get_possible_universes() == [1]
+    # add universe 2
+    packet.universe = 2
+    socket.call_on_data(bytes(packet.getBytes()), 0)
+    assert handler.get_possible_universes() == [1, 2]
+    # remove universe 2
+    packet.option_StreamTerminated = True
+    socket.call_on_data(bytes(packet.getBytes()), 0)
+    assert handler.get_possible_universes() == [1]
+
+
+def test_universe_timeout():
+    _, listener, socket = get_handler()
+    assert listener.on_availability_change_changed is None
+    assert listener.on_availability_change_universe is None
+    packet = DataPacket(
+        cid=tuple(range(0, 16)),
+        sourceName='Test',
+        universe=1,
+        dmxData=tuple(range(0, 16))
+    )
+    socket.call_on_data(bytes(packet.getBytes()), 0)
+    socket.call_on_periodic_callback(0)
+    assert listener.on_availability_change_changed == 'available'
+    assert listener.on_availability_change_universe == 1
+    # wait the specified amount of time and check, that a timeout was triggered
+    # add 10ms of grace time
+    socket.call_on_periodic_callback((E131_NETWORK_DATA_LOSS_TIMEOUT_ms / 1000) + 0.01)
+    assert listener.on_availability_change_changed == 'timeout'
+    assert listener.on_availability_change_universe == 1
+
+
+def test_universe_stream_terminated():
+    _, listener, socket = get_handler()
+    assert listener.on_availability_change_changed is None
+    assert listener.on_availability_change_universe is None
+    packet = DataPacket(
+        cid=tuple(range(0, 16)),
+        sourceName='Test',
+        universe=1,
+        dmxData=tuple(range(0, 16))
+    )
+    socket.call_on_data(bytes(packet.getBytes()), 0)
+    assert listener.on_availability_change_changed == 'available'
+    assert listener.on_availability_change_universe == 1
+    packet.sequence_increase()
+    packet.option_StreamTerminated = True
+    socket.call_on_data(bytes(packet.getBytes()), 0)
+    assert listener.on_availability_change_changed == 'timeout'
+    assert listener.on_availability_change_universe == 1
+
+
+def test_abstract_receiver_handler_listener():
+    listener = ReceiverHandlerListener()
+    with pytest.raises(NotImplementedError):
+        listener.on_availability_change(1, 'test')
+    with pytest.raises(NotImplementedError):
+        listener.on_dmx_data_change(DataPacket(
+            cid=tuple(range(0, 16)),
+            sourceName='Test',
+            universe=1
+        ))

--- a/sacn/receiving/receiver_socket_base.py
+++ b/sacn/receiving/receiver_socket_base.py
@@ -1,0 +1,37 @@
+# This file is under MIT license. The license file can be obtained in the root directory of this module.
+
+import logging
+
+
+class ReceiverSocketListener:
+    """
+    Base class for listener of a ReceiverSocketBase.
+    """
+
+    def on_data(self, data: bytes, current_time: float) -> None:
+        raise NotImplementedError
+
+    def on_periodic_callback(self, current_time: float) -> None:
+        raise NotImplementedError
+
+
+class ReceiverSocketBase:
+    """
+    Base class for abstracting a UDP receiver socket.
+    """
+
+    def __init__(self, listener: ReceiverSocketListener):
+        self._logger: logging.Logger = logging.getLogger('sacn')
+        self._listener: ReceiverSocketListener = listener
+
+    def start(self) -> None:
+        raise NotImplementedError
+
+    def stop(self) -> None:
+        raise NotImplementedError
+
+    def join_multicast(self, multicast_addr: str) -> None:
+        raise NotImplementedError
+
+    def leave_multicast(self, multicast_addr: str) -> None:
+        raise NotImplementedError

--- a/sacn/receiving/receiver_socket_base_test.py
+++ b/sacn/receiving/receiver_socket_base_test.py
@@ -1,0 +1,24 @@
+# This file is under MIT license. The license file can be obtained in the root directory of this module.
+
+import pytest
+from dmx.sacn.receiving.receiver_socket_base import ReceiverSocketBase, ReceiverSocketListener
+
+
+def test_abstract_receiver_socket_listener():
+    listener = ReceiverSocketListener()
+    with pytest.raises(NotImplementedError):
+        listener.on_data([], 0)
+    with pytest.raises(NotImplementedError):
+        listener.on_periodic_callback(0)
+
+
+def test_abstract_receiver_socket_base():
+    socket = ReceiverSocketBase(None)
+    with pytest.raises(NotImplementedError):
+        socket.start()
+    with pytest.raises(NotImplementedError):
+        socket.stop()
+    with pytest.raises(NotImplementedError):
+        socket.join_multicast('test')
+    with pytest.raises(NotImplementedError):
+        socket.leave_multicast('test')

--- a/sacn/receiving/receiver_socket_test.py
+++ b/sacn/receiving/receiver_socket_test.py
@@ -1,0 +1,31 @@
+# This file is under MIT license. The license file can be obtained in the root directory of this module.
+
+
+from dmx.sacn.receiving.receiver_socket_base import ReceiverSocketBase
+
+
+class ReceiverSocketTest(ReceiverSocketBase):
+    def __init__(self, listener=None):
+        super().__init__(listener)
+        self.start_called: bool = False
+        self.stop_called: bool = False
+        self.join_multicast_called: str = None
+        self.leave_multicast_called: str = None
+
+    def start(self) -> None:
+        self.start_called = True
+
+    def stop(self) -> None:
+        self.stop_called = True
+
+    def join_multicast(self, multicast_addr: str) -> None:
+        self.join_multicast_called = multicast_addr
+
+    def leave_multicast(self, multicast_addr: str) -> None:
+        self.leave_multicast_called = multicast_addr
+
+    def call_on_data(self, data: bytes, current_time: float) -> None:
+        self._listener.on_data(data, current_time)
+
+    def call_on_periodic_callback(self, current_time: float) -> None:
+        self._listener.on_periodic_callback(current_time)

--- a/sacn/receiving/receiver_socket_udp.py
+++ b/sacn/receiving/receiver_socket_udp.py
@@ -1,0 +1,95 @@
+# This file is under MIT license. The license file can be obtained in the root directory of this module.
+
+import socket
+import threading
+import time
+from dmx.sacn.receiving.receiver_socket_base import ReceiverSocketBase, ReceiverSocketListener
+
+THREAD_NAME = 'sACN input/receiver thread'
+
+
+class ReceiverSocketUDP(ReceiverSocketBase):
+    """
+    Implements a receiver socket with a UDP socket of the OS.
+    """
+
+    def __init__(self, listener: ReceiverSocketListener, bind_address: str, bind_port: int):
+        super().__init__(listener=listener)
+
+        self._bind_address: str = bind_address
+        self._bind_port: int = bind_port
+        self._enabled_flag: bool = True
+
+        # initialize the UDP socket
+        self._socket: socket.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+        try:
+            self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        except socket.error:  # Not all systems support multiple sockets on the same port and interface
+            pass
+        self._socket.bind((self._bind_address, self._bind_port))
+        self._logger.info(f'Bind receiver socket to IP: {self._bind_address} port: {self._bind_port}')
+
+    def start(self):
+        # initialize thread infos
+        self._thread = threading.Thread(
+            target=self.receive_loop,
+            name=THREAD_NAME
+        )
+        # self._thread.setDaemon(True)  # TODO: might be beneficial to use a daemon thread
+        self._thread.start()
+
+    def receive_loop(self) -> None:
+        """
+        Implements the run method inherited by threading.Thread
+        """
+        self._logger.info(f'Started {THREAD_NAME}')
+        self._socket.settimeout(0.1)  # timeout as 100ms
+        self._enabled_flag = True
+        while self._enabled_flag:
+            # before receiving: invoke periodic callback
+            self._listener.on_periodic_callback(time.time())
+            # receive the data
+            try:
+                raw_data = list(self._socket.recv(2048))  # greater than 1144 because the longest possible packet
+                # in the sACN standard is the universe discovery packet with a max length of 1144
+            except socket.timeout:
+                continue  # if a timeout happens just go through while from the beginning
+            self._listener.on_data(raw_data, time.time())
+
+        self._logger.info(f'Stopped {THREAD_NAME}')
+
+    def stop(self) -> None:
+        """
+        Stops a running thread and closes the underlying socket. If no thread was started, nothing happens.
+        Do not reuse the socket after calling stop once.
+        """
+        self._enabled_flag = False
+        try:
+            self._thread.join()
+            # stop the socket, after the loop terminated
+            self._socket.close()
+        except AttributeError:
+            pass
+
+    def join_multicast(self, multicast_addr: str) -> None:
+        """
+        Join a specific multicast address by string. Only IPv4.
+        """
+        # Windows: https://learn.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options
+        # Linux: https://man7.org/linux/man-pages/man7/ip.7.html
+        self._socket.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP,
+                                socket.inet_aton(multicast_addr) +
+                                socket.inet_aton(self._bind_address))
+
+    def leave_multicast(self, multicast_addr: str) -> None:
+        """
+        Leave a specific multicast address by string. Only IPv4.
+        """
+        # Windows: https://learn.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options
+        # Linux: https://man7.org/linux/man-pages/man7/ip.7.html
+        try:
+            self._socket.setsockopt(socket.IPPROTO_IP, socket.IP_DROP_MEMBERSHIP,
+                                    socket.inet_aton(multicast_addr) +
+                                    socket.inet_aton(self._bind_address))
+        except socket.error:  # try to leave the multicast group for the universe
+            pass

--- a/sacn/sender.py
+++ b/sacn/sender.py
@@ -1,0 +1,163 @@
+# This file is under MIT license. The license file can be obtained in the root directory of this module.
+
+"""
+This is a server for sending out sACN and receiving sACN data.
+http://tsp.esta.org/tsp/documents/docs/E1-31-2016.pdf
+"""
+
+import random
+import time
+from typing import Dict, List, Optional
+
+from dmx.sacn.messages.data_packet import DataPacket
+from dmx.sacn.sending.output import Output
+from dmx.sacn.sending.sender_socket_base import SenderSocketBase, DEFAULT_PORT
+from dmx.sacn.sending.sender_handler import SenderHandler
+
+
+class sACNsender:
+    def __init__(self, bind_address: str = '0.0.0.0', bind_port: int = DEFAULT_PORT,
+                 source_name: str = 'default source name', cid: tuple = (),
+                 fps: int = 30, universeDiscovery: bool = True,
+                 sync_universe: int = 63999, socket: SenderSocketBase = None):
+        """
+        Creates a sender object. A sender is used to manage multiple sACN universes and handles their sending.
+        DMX data is send out every second, when no data changes. Some changes may be not send out, because the fps
+        setting defines how often packets are send out to prevent network overuse. So if you change the DMX values too
+        often in a second they may not all been send. Vary the fps parameter to your needs (Default=30).
+        Note that a bind address is needed on Windows for sending out multicast packets.
+        :param bind_address: the IP-Address to bind to.
+        For multicast on a Windows machine this must be set to a proper value otherwise omit.
+        :param bind_port: optionally bind to a specific port. Default=5568. It is not recommended to change the port.
+        Change the port number if you have trouble with another program or the sACNreceiver blocking the port
+        :param source_name: the source name used in the sACN packets.
+        :param cid: the cid. If not given, a random CID will be generated.
+        :param fps: the frames per second. See above explanation. Has to be >0
+        :param sync_universe: universe to send sync packets on.
+        :param socket: Provide a special socket implementation if necessary. Must be derived from SenderSocketBase,
+        only use if the default socket implementation of this library is not sufficient.
+        """
+        if len(cid) != 16:
+            cid = tuple(int(random.random() * 255) for _ in range(0, 16))
+        self._outputs: Dict[int, Output] = {}
+        self._sender_handler = SenderHandler(cid, source_name, self._outputs, bind_address, bind_port, fps, socket)
+        self.universeDiscovery = universeDiscovery
+        self._sync_universe: int = sync_universe
+
+    @property
+    def universeDiscovery(self) -> bool:
+        return self._sender_handler.universe_discovery
+
+    @universeDiscovery.setter
+    def universeDiscovery(self, universeDiscovery: bool) -> None:
+        self._sender_handler.universe_discovery = universeDiscovery
+
+    @property
+    def manual_flush(self) -> bool:
+        return self._sender_handler.manual_flush
+
+    @manual_flush.setter
+    def manual_flush(self, manual_flush: bool) -> None:
+        self._sender_handler.manual_flush = manual_flush
+
+    def flush(self, universes: List[int] = []):
+        """
+        Sends out all universes in one go. This is done on the caller's thread!
+        This uses the E1.31 sync mechanism to try to sync all universes.
+        Note that not all receivers support this feature.
+        :param universes: a list of universes to send. If not given, all will be sent.
+        :raises ValueError: when attempting to flush a universe that is not activated.
+        """
+        for uni in universes:
+            if uni not in self._outputs:
+                raise ValueError(f'Cannot flush universe {uni}, it is not active!')
+        self._sender_handler.send_out_all_universes(
+            self._sync_universe,
+            self._outputs if not universes else {uni: self._outputs[uni] for uni in universes},
+            time.time()
+        )
+
+    def activate_output(self, universe: int) -> None:
+        """
+        Activates a universe that's then starting to sending every second.
+        See http://tsp.esta.org/tsp/documents/docs/E1-31-2016.pdf for more information
+        :param universe: the universe to activate
+        """
+        check_universe(universe)
+        # check, if the universe already exists in the list:
+        if universe in self._outputs:
+            return
+        # add new sending:
+        new_output = Output(DataPacket(cid=self._sender_handler._CID, sourceName=self._sender_handler._source_name, universe=universe))
+        self._outputs[universe] = new_output
+
+    def deactivate_output(self, universe: int) -> None:
+        """
+        Deactivates an existing sending. Every data from the existing sending output will be lost.
+        (TTL, Multicast, DMX data, ..)
+        :param universe: the universe to deactivate. If the universe was not activated before, no error is raised
+        """
+        check_universe(universe)
+        try:  # try to send out three messages with stream_termination bit set to 1
+            self._outputs[universe]._packet.option_StreamTerminated = True
+            for _ in range(0, 3):
+                self._sender_handler.send_out(self._outputs[universe], time.time())
+        except KeyError:
+            pass
+        try:
+            del self._outputs[universe]
+        except KeyError:
+            pass
+
+    def get_active_outputs(self) -> tuple:
+        """
+        Returns a list with all active outputs. Useful when iterating over all sender indexes.
+        :return: list: a list with int (every int is a activated universe. May be not sorted)
+        """
+        return tuple(self._outputs.keys())
+
+    def move_universe(self, universe_from: int, universe_to: int) -> None:
+        """
+        Moves an sending from one universe to another. All settings are being restored and only the universe changes
+        :param universe_from: the universe that should be moved
+        :param universe_to: the target universe. An existing universe will be overwritten
+        """
+        check_universe(universe_from)
+        check_universe(universe_to)
+        # store the sending object and change the universe in the packet of the sending
+        tmp_output = self._outputs[universe_from]
+        # deactivate sending
+        self.deactivate_output(universe_from)
+        # activate new sending with the new universe
+        tmp_output._packet.universe = universe_to
+        tmp_output._packet.option_StreamTerminated = False
+        self._outputs[universe_to] = tmp_output
+
+    def __getitem__(self, item: int) -> Optional[Output]:
+        try:
+            return self._outputs[item]
+        except KeyError:
+            return None
+
+    def start(self) -> None:
+        """
+        Starts or restarts a new Thread with the parameters given in the constructor.
+        """
+        self.stop()
+        self._sender_handler.start()
+
+    def stop(self) -> None:
+        """
+        Stops a running thread and closes the underlying socket. If no thread was started, nothing happens.
+        Do not reuse the socket after calling stop once.
+        """
+        self._sender_handler.stop()
+
+    def __del__(self):
+        # stop a potential running thread
+        self.stop()
+
+
+def check_universe(universe: int):
+    if universe not in range(1, 64000):
+        raise ValueError(f'Universe must be between [1-63999]! Universe was {universe}')

--- a/sacn/sender_test.py
+++ b/sacn/sender_test.py
@@ -1,0 +1,293 @@
+# This file is under MIT license. The license file can be obtained in the root directory of this module.
+
+import pytest
+import sacn
+from dmx.sacn.sender import check_universe
+from dmx.sacn.messages.data_packet import DataPacket
+from dmx.sacn.sending.sender_socket_test import SenderSocketTest
+
+
+def test_constructor():
+    cid = tuple(range(0, 16))
+    source_name = 'test'
+    socket = SenderSocketTest()
+
+    # test default values for constructor
+    sender = sacn.sACNsender(socket=socket)
+    assert sender._sender_handler._source_name == 'default source name'
+    assert len(sender._sender_handler._CID) == 16
+    assert sender.universeDiscovery is True
+    assert sender._sync_universe == 63999
+    assert sender.manual_flush is False
+
+    # test explicit values for constructor
+    bind_address = 'test_address'
+    bind_port = 1234
+    fps = 40
+    universe_discovery = False
+    sync_universe = 4567
+    sender = sacn.sACNsender(bind_address, bind_port, source_name, cid, fps, universe_discovery, sync_universe, socket)
+    assert sender._sender_handler._source_name == source_name
+    assert sender._sender_handler._CID == cid
+    assert sender.universeDiscovery == universe_discovery
+    assert sender._sync_universe == sync_universe
+    assert sender.manual_flush is False
+
+
+def test_universe_discovery_setting():
+    socket = SenderSocketTest()
+    sender = sacn.sACNsender(socket=socket)
+    assert sender.universeDiscovery is True
+    assert sender._sender_handler.universe_discovery is True
+    sender.universeDiscovery = False
+    assert sender.universeDiscovery is False
+    assert sender._sender_handler.universe_discovery is False
+
+
+def test_manual_flush_setting():
+    socket = SenderSocketTest()
+    sender = sacn.sACNsender(socket=socket)
+    assert sender.manual_flush is False
+    assert sender._sender_handler.manual_flush is False
+    sender.manual_flush = True
+    assert sender.manual_flush is True
+    assert sender._sender_handler.manual_flush is True
+
+
+def test_flush():
+    socket = SenderSocketTest()
+    sync_universe = 1234
+    sender = sacn.sACNsender(sync_universe=sync_universe, socket=socket)
+
+    assert socket.send_unicast_called is None
+    # test that non-active universes throw exception
+    with pytest.raises(ValueError):
+        sender.flush([1, 2])
+
+    assert socket.send_unicast_called is None
+    # test that no active universes triggers nothing
+    sender.flush()
+    assert socket.send_unicast_called is None
+
+    # activate universe 1
+    sender.activate_output(1)
+    assert socket.send_unicast_called is None
+    # test that no parameters triggers flushing of all universes
+    sender.flush()
+    assert socket.send_unicast_called[0].__dict__ == DataPacket(
+        sender._sender_handler._CID, sender._sender_handler._source_name, 1, sync_universe=sync_universe).__dict__
+
+    # activate universe 2
+    sender.activate_output(2)
+    # test that a list with only universe 1 triggers flushing of only this universe
+    sender.flush([1])
+    assert socket.send_unicast_called[0].__dict__ == DataPacket(
+        sender._sender_handler._CID, sender._sender_handler._source_name, 1, sequence=1, sync_universe=sync_universe).__dict__
+
+
+def test_activate_output():
+    socket = SenderSocketTest()
+    sender = sacn.sACNsender(socket=socket)
+
+    # start with no universes active
+    assert list(sender._outputs.keys()) == []
+
+    # activate one universe
+    sender.activate_output(1)
+    assert list(sender._outputs.keys()) == [1]
+
+    # activate another universe
+    sender.activate_output(63999)
+    assert list(sender._outputs.keys()) == [1, 63999]
+
+    # check that a universe can not be enabled twice
+    sender.activate_output(1)
+    assert list(sender._outputs.keys()) == [1, 63999]
+
+
+def test_deactivate_output():
+    socket = SenderSocketTest()
+    sender = sacn.sACNsender(socket=socket)
+
+    # check that three packets with stream-termination bit set are send out on deactivation
+    sender.activate_output(100)
+    assert socket.send_unicast_called is None
+    sender.deactivate_output(100)
+    assert socket.send_unicast_called[0].__dict__ == DataPacket(
+        sender._sender_handler._CID, sender._sender_handler._source_name, 100, sequence=2, streamTerminated=True).__dict__
+
+    # start with no universes active
+    assert list(sender._outputs.keys()) == []
+    sender.deactivate_output(1)
+    assert list(sender._outputs.keys()) == []
+
+    # one universe active
+    sender.activate_output(1)
+    assert list(sender._outputs.keys()) == [1]
+    sender.deactivate_output(1)
+    assert list(sender._outputs.keys()) == []
+
+    # two universes active
+    sender.activate_output(10)
+    sender.activate_output(11)
+    assert list(sender._outputs.keys()) == [10, 11]
+    sender.deactivate_output(10)
+    assert list(sender._outputs.keys()) == [11]
+
+    # deactivate no active universe
+    assert list(sender._outputs.keys()) == [11]
+    sender.deactivate_output(99)
+    assert list(sender._outputs.keys()) == [11]
+
+
+def test_get_active_outputs():
+    socket = SenderSocketTest()
+    sender = sacn.sACNsender(socket=socket)
+
+    # none active
+    assert sender.get_active_outputs() == tuple([])
+
+    # one active
+    sender.activate_output(1)
+    assert sender.get_active_outputs() == tuple([1])
+
+    # two active
+    sender.activate_output(2)
+    assert sender.get_active_outputs() == tuple([1, 2])
+
+
+def test_move_universe():
+    socket = SenderSocketTest()
+    sender = sacn.sACNsender(socket=socket)
+
+    sender.activate_output(1)
+    output = sender._outputs[1]
+    assert list(sender._outputs.keys()) == [1]
+    assert sender._outputs[1] == output
+    sender.move_universe(1, 2)
+    assert list(sender._outputs.keys()) == [2]
+    assert sender._outputs[2] == output
+
+
+def test_getitem():
+    socket = SenderSocketTest()
+    sender = sacn.sACNsender(socket=socket)
+
+    assert sender[1] is None
+    sender.activate_output(1)
+    assert sender[1] == sender._outputs[1]
+
+
+def test_start():
+    socket = SenderSocketTest()
+    sender = sacn.sACNsender(socket=socket)
+
+    assert socket.start_called is False
+    sender.start()
+    assert socket.start_called is True
+
+    # a second time is not allowed to throw an exception
+    assert socket.start_called is True
+    sender.start()
+    assert socket.start_called is True
+
+
+def test_stop():
+    socket = SenderSocketTest()
+    sender = sacn.sACNsender(socket=socket)
+
+    assert socket.stop_called is False
+    sender.stop()
+    assert socket.stop_called is True
+
+    # a second time is not allowed to throw an exception
+    assert socket.stop_called is True
+    sender.stop()
+    assert socket.stop_called is True
+
+
+def test_output_destination():
+    socket = SenderSocketTest()
+    sender = sacn.sACNsender(socket=socket)
+    sender.activate_output(1)
+
+    # test default
+    assert sender[1].destination == '127.0.0.1'
+    # test setting and retriving the value
+    test = 'test'
+    sender[1].destination = test
+    assert sender[1].destination == test
+
+
+def test_output_multicast():
+    socket = SenderSocketTest()
+    sender = sacn.sACNsender(socket=socket)
+    sender.activate_output(1)
+
+    # test default
+    assert sender[1].multicast is False
+    # test setting and retriving the value
+    test = True
+    sender[1].multicast = test
+    assert sender[1].multicast == test
+
+
+def test_output_ttl():
+    socket = SenderSocketTest()
+    sender = sacn.sACNsender(socket=socket)
+    sender.activate_output(1)
+
+    # test default
+    assert sender[1].ttl == 8
+    # test setting and retriving the value
+    test = 16
+    sender[1].ttl = test
+    assert sender[1].ttl == test
+
+
+def test_output_priority():
+    socket = SenderSocketTest()
+    sender = sacn.sACNsender(socket=socket)
+    sender.activate_output(1)
+
+    # test default
+    assert sender[1].priority == 100
+    # test setting and retriving the value
+    test = 200
+    sender[1].priority = test
+    assert sender[1].priority == test
+
+
+def test_output_preview_data():
+    socket = SenderSocketTest()
+    sender = sacn.sACNsender(socket=socket)
+    sender.activate_output(1)
+
+    # test default
+    assert sender[1].preview_data is False
+    # test setting and retriving the value
+    test = True
+    sender[1].preview_data = test
+    assert sender[1].preview_data == test
+
+
+def test_output_dmx_data():
+    socket = SenderSocketTest()
+    sender = sacn.sACNsender(socket=socket)
+    sender.activate_output(1)
+
+    # test default
+    assert sender[1].dmx_data == tuple([0]*512)
+    # test setting and retriving the value
+    test = tuple([x % 256 for x in range(0, 512)])
+    sender[1].dmx_data = test
+    assert sender[1].dmx_data == test
+
+
+def test_check_universe():
+    with pytest.raises(ValueError):
+        check_universe(0)
+    with pytest.raises(ValueError):
+        check_universe(64000)
+    check_universe(1)
+    check_universe(63999)

--- a/sacn/sending/output.py
+++ b/sacn/sending/output.py
@@ -1,0 +1,43 @@
+# This file is under MIT license. The license file can be obtained in the root directory of this module.
+
+from dmx.sacn.messages.data_packet import DataPacket
+
+
+class Output:
+    """
+    This class is a compact representation of an sending with all relevant information
+    """
+
+    def __init__(self, packet: DataPacket, last_time_send: int = 0, destination: str = '127.0.0.1',
+                 multicast: bool = False, ttl: int = 8):
+        self._packet: DataPacket = packet
+        self._last_time_send: int = last_time_send
+        self.destination: str = destination
+        self.multicast: bool = multicast
+        self.ttl: int = ttl
+        self._changed: bool = False
+
+    @property
+    def dmx_data(self) -> tuple:
+        return self._packet.dmxData
+
+    @dmx_data.setter
+    def dmx_data(self, dmx_data: tuple):
+        self._packet.dmxData = dmx_data
+        self._changed = True
+
+    @property
+    def priority(self) -> int:
+        return self._packet.priority
+
+    @priority.setter
+    def priority(self, priority: int):
+        self._packet.priority = priority
+
+    @property
+    def preview_data(self) -> bool:
+        return self._packet.option_PreviewData
+
+    @preview_data.setter
+    def preview_data(self, preview_data: bool):
+        self._packet.option_PreviewData = preview_data

--- a/sacn/sending/sender_handler.py
+++ b/sacn/sending/sender_handler.py
@@ -1,0 +1,95 @@
+# This file is under MIT license. The license file can be obtained in the root directory of this module.
+
+from typing import Dict
+from dmx.sacn.messages.universe_discovery import UniverseDiscoveryPacket
+from dmx.sacn.messages.sync_packet import SyncPacket
+from dmx.sacn.messages.data_packet import calculate_multicast_addr
+from dmx.sacn.sending.output import Output
+from dmx.sacn.sending.sender_socket_base import SenderSocketBase, SenderSocketListener
+from dmx.sacn.sending.sender_socket_udp import SenderSocketUDP
+
+SEND_OUT_INTERVAL = 1
+E131_E131_UNIVERSE_DISCOVERY_INTERVAL = 10
+
+
+class SenderHandler(SenderSocketListener):
+    # TODO: start using type CID instead of tuple
+    def __init__(self, cid: tuple, source_name: str, outputs: Dict[int, Output], bind_address: str, bind_port: int, fps: int, socket: SenderSocketBase = None):
+        """
+        This is a private class and should not be used elsewhere. It handles the sender state with sACN specific values.
+        Uses a UDP sender socket with the given bind-address and -port, if the socket was not provided (i.e. None).
+        """
+        if socket is None:
+            self.socket: SenderSocketBase = SenderSocketUDP(self, bind_address, bind_port, fps)
+        else:
+            self.socket: SenderSocketBase = socket
+
+        self._CID = cid
+        self._source_name = source_name
+        self.universe_discovery: bool = True
+        self._last_time_universe_discover: float = 0
+        self._outputs: Dict[int, Output] = outputs
+        self.manual_flush: bool = False
+        self._sync_sequence = 0
+
+    def on_periodic_callback(self, current_time: float) -> None:
+        # send out universe discovery packets if necessary
+        if self.universe_discovery and \
+              abs(current_time - self._last_time_universe_discover) >= E131_E131_UNIVERSE_DISCOVERY_INTERVAL:
+            self.send_universe_discovery_packets()
+            self._last_time_universe_discover = current_time
+
+        # go through the list of outputs and send everything out that has to be send out
+        # Note: dict may changes size during iteration (multithreading)
+        [self.send_out(output, current_time) for output in list(self._outputs.values())
+            # only send if the manual flush feature is disabled
+            # send out when the 1 second interval is over
+            if not self.manual_flush and \
+            (output._changed or abs(current_time - output._last_time_send) >= SEND_OUT_INTERVAL)]
+
+    def send_out(self, output: Output, current_time: float):
+        # 1st: Destination (check if multicast)
+        if output.multicast:
+            udp_ip = output._packet.calculate_multicast_addr()
+            self.socket.send_multicast(output._packet, udp_ip, output.ttl)
+        else:
+            udp_ip = output.destination
+            self.socket.send_unicast(output._packet, udp_ip)
+
+        output._last_time_send = current_time
+        # increase the sequence counter
+        output._packet.sequence_increase()
+        # the changed flag is not necessary any more
+        output._changed = False
+
+    def send_universe_discovery_packets(self):
+        packets = UniverseDiscoveryPacket.make_multiple_uni_disc_packets(
+            cid=self._CID, sourceName=self._source_name, universes=list(self._outputs.keys()))
+        for packet in packets:
+            self.socket.send_broadcast(packet)
+
+    def send_out_all_universes(self, sync_universe: int, universes: dict, current_time: float):
+        """
+        Sends out all universes in one go. This is not done by this thread! This is done by the caller's thread.
+        This uses the E1.31 sync mechanism to try to sync all universes.
+        Note that not all receivers support this feature.
+        """
+        # go through the list of outputs and send everything out
+        # Note: dict may changes size during iteration (multithreading)
+        for output in list(universes.values()):
+            output._packet.syncAddr = sync_universe  # temporarily set the sync universe
+            self.send_out(output, current_time)
+            output._packet.syncAddr = 0
+
+        sync_packet = SyncPacket(cid=self._CID, syncAddr=sync_universe, sequence=self._sync_sequence)
+        # Increment sequence number for next time.
+        self._sync_sequence += 1
+        if self._sync_sequence > 255:
+            self._sync_sequence = 0
+        self.socket.send_multicast(sync_packet, calculate_multicast_addr(sync_universe), 255)
+
+    def start(self):
+        self.socket.start()
+
+    def stop(self):
+        self.socket.stop()

--- a/sacn/sending/sender_handler_test.py
+++ b/sacn/sending/sender_handler_test.py
@@ -1,0 +1,187 @@
+# This file is under MIT license. The license file can be obtained in the root directory of this module.
+
+from typing import Dict
+from dmx.sacn.messages.data_packet import DataPacket, calculate_multicast_addr
+from dmx.sacn.messages.sync_packet import SyncPacket
+from dmx.sacn.messages.universe_discovery import UniverseDiscoveryPacket
+from dmx.sacn.sending.output import Output
+from dmx.sacn.sending.sender_handler import SenderHandler
+from dmx.sacn.sending.sender_socket_test import SenderSocketTest
+
+
+def get_handler():
+    cid = tuple(range(0, 16))
+    source_name = 'test'
+    outputs: Dict[int, Output] = {
+        1: Output(
+            packet=DataPacket(
+                cid=cid,
+                sourceName=source_name,
+                universe=1,
+            )
+        )
+    }
+    socket = SenderSocketTest()
+    handler = SenderHandler(
+        cid=cid,
+        source_name=source_name,
+        outputs=outputs,
+        bind_address='0.0.0.0',
+        bind_port=5568,
+        fps=30,
+        socket=socket,
+    )
+    handler.manual_flush = True
+    # wire up listener for tests
+    socket._listener = handler
+    return handler, socket, cid, source_name, outputs
+
+
+def test_universe_discovery_packets():
+    handler, socket, cid, source_name, outputs = get_handler()
+    handler.manual_flush = True
+    current_time = 100.0
+
+    assert handler.universe_discovery is True
+    assert socket.send_broadcast_called is None
+
+    # test that the universe discovery can be disabled
+    handler.universe_discovery = False
+    socket.call_on_periodic_callback(current_time)
+    assert socket.send_broadcast_called is None
+    handler.universe_discovery = True
+
+    # if no outputs are specified, there is an empty universe packet send
+    socket.call_on_periodic_callback(current_time)
+    assert socket.send_broadcast_called == UniverseDiscoveryPacket(cid, source_name, (1,))
+
+
+def test_send_out_interval():
+    handler, socket, cid, source_name, outputs = get_handler()
+    handler.manual_flush = False
+    current_time = 100.0
+
+    assert handler.manual_flush is False
+    assert socket.send_unicast_called is None
+
+    # first send packet due to interval
+    socket.call_on_periodic_callback(current_time)
+    assert socket.send_unicast_called[0].__dict__ == DataPacket(cid, source_name, 1, sequence=0).__dict__
+    assert socket.send_unicast_called[1] == '127.0.0.1'
+
+    # interval must be 1 seconds
+    socket.call_on_periodic_callback(current_time+0.99)
+    assert socket.send_unicast_called[0].__dict__ == DataPacket(cid, source_name, 1, sequence=0).__dict__
+    socket.call_on_periodic_callback(current_time+1.01)
+    assert socket.send_unicast_called[0].__dict__ == DataPacket(cid, source_name, 1, sequence=1).__dict__
+
+
+def test_multicast():
+    handler, socket, cid, source_name, outputs = get_handler()
+    handler.manual_flush = False
+    current_time = 100.0
+    outputs[1].multicast = True
+    outputs[1].ttl = 123
+
+    assert handler.manual_flush is False
+    assert socket.send_multicast_called is None
+    assert outputs[1].multicast is True
+    assert outputs[1].ttl == 123
+
+    # first send packet due to interval
+    socket.call_on_periodic_callback(current_time)
+    assert socket.send_multicast_called[0].__dict__ == DataPacket(cid, source_name, 1, sequence=0).__dict__
+    assert socket.send_multicast_called[1] == calculate_multicast_addr(1)
+
+    # only send out on dmx change
+    # test same data as before
+    # TODO: currently there is no "are the values different" check.
+    # If it is implemented, enable the following line:
+    # outputs[1].dmx_data = (0, 0)
+    socket.call_on_periodic_callback(current_time)
+    assert socket.send_multicast_called[0].__dict__ == DataPacket(cid, source_name, 1, sequence=0).__dict__
+    assert socket.send_multicast_called[1] == calculate_multicast_addr(1)
+
+    # test change in data as before
+    outputs[1].dmx_data = (1, 2)
+    socket.call_on_periodic_callback(current_time)
+    assert socket.send_multicast_called[0].__dict__ == DataPacket(cid, source_name, 1, sequence=1, dmxData=(1, 2)).__dict__
+    assert socket.send_multicast_called[1] == calculate_multicast_addr(1)
+
+    # assert that no unicast was send
+    assert socket.send_unicast_called is None
+
+
+def test_unicast():
+    handler, socket, cid, source_name, outputs = get_handler()
+    handler.manual_flush = False
+    current_time = 100.0
+    outputs[1].multicast = False
+    destination = "1.2.3.4"
+    outputs[1].destination = destination
+
+    assert handler.manual_flush is False
+    assert socket.send_unicast_called is None
+    assert outputs[1].multicast is False
+
+    # first send packet due to interval
+    socket.call_on_periodic_callback(current_time)
+    assert socket.send_unicast_called[0].__dict__ == DataPacket(cid, source_name, 1, sequence=0).__dict__
+    assert socket.send_unicast_called[1] == destination
+
+    # only send out on dmx change
+    # test same data as before
+    # TODO: currently there is no "are the values different" check.
+    # If it is implemented, enable the following line:
+    # outputs[1].dmx_data = (0, 0)
+    socket.call_on_periodic_callback(current_time)
+    assert socket.send_unicast_called[0].__dict__ == DataPacket(cid, source_name, 1, sequence=0).__dict__
+    assert socket.send_unicast_called[1] == destination
+
+    # test change in data as before
+    outputs[1].dmx_data = (1, 2)
+    socket.call_on_periodic_callback(current_time)
+    assert socket.send_unicast_called[0].__dict__ == DataPacket(cid, source_name, 1, sequence=1, dmxData=(1, 2)).__dict__
+    assert socket.send_unicast_called[1] == destination
+
+    # assert that no multicast was send
+    assert socket.send_multicast_called is None
+
+
+def test_send_out_all_universes():
+    handler, socket, cid, source_name, outputs = get_handler()
+    handler.manual_flush = True
+    current_time = 100.0
+    outputs[1].multicast = False
+    destination = "1.2.3.4"
+    outputs[1].destination = destination
+
+    assert handler.manual_flush is True
+    assert socket.send_unicast_called is None
+    assert socket.send_multicast_called is None
+    assert outputs[1].multicast is False
+
+    # check that send packets due to interval are suppressed
+    socket.call_on_periodic_callback(current_time)
+    assert socket.send_unicast_called is None
+    assert socket.send_multicast_called is None
+
+    # after calling send_out_all_universes, the DataPackets need to send, as well as one SyncPacket
+    sync_universe = 63999
+    handler.send_out_all_universes(sync_universe, outputs, current_time)
+    assert socket.send_unicast_called[0].__dict__ == DataPacket(cid, source_name, 1, sequence=0, sync_universe=sync_universe).__dict__
+    assert socket.send_unicast_called[1] == destination
+    assert socket.send_multicast_called[0].__dict__ == SyncPacket(cid, sync_universe, 0).__dict__
+    assert socket.send_multicast_called[1] == calculate_multicast_addr(sync_universe)
+
+
+def test_send_out_all_universes_sequence_increment():
+    handler, socket, cid, source_name, outputs = get_handler()
+    handler.manual_flush = True
+    current_time = 100.0
+    sync_universe = 63999
+
+    # check that the sequence number never exceeds the range [0-255]
+    for i in range(0, 300):
+        handler.send_out_all_universes(sync_universe, outputs, current_time)
+        assert socket.send_multicast_called[0].__dict__ == SyncPacket(cid, sync_universe, (i % 256)).__dict__

--- a/sacn/sending/sender_socket_base.py
+++ b/sacn/sending/sender_socket_base.py
@@ -1,0 +1,40 @@
+# This file is under MIT license. The license file can be obtained in the root directory of this module.
+
+import logging
+from dmx.sacn.messages.root_layer import RootLayer
+
+DEFAULT_PORT = 5568
+
+
+class SenderSocketListener:
+    """
+    Base class for listener of a SenderSocketListener.
+    """
+
+    def on_periodic_callback(self, time: float) -> None:
+        raise NotImplementedError
+
+
+class SenderSocketBase:
+    """
+    Base class for abstracting a UDP sending socket.
+    """
+
+    def __init__(self, listener: SenderSocketListener):
+        self._logger: logging.Logger = logging.getLogger('sacn')
+        self._listener: SenderSocketListener = listener
+
+    def start(self) -> None:
+        raise NotImplementedError
+
+    def stop(self) -> None:
+        raise NotImplementedError
+
+    def send_unicast(self, data: RootLayer, destination: str) -> None:
+        raise NotImplementedError
+
+    def send_multicast(self, data: RootLayer, destination: str, ttl: int) -> None:
+        raise NotImplementedError
+
+    def send_broadcast(self, data: RootLayer) -> None:
+        raise NotImplementedError

--- a/sacn/sending/sender_socket_base_test.py
+++ b/sacn/sending/sender_socket_base_test.py
@@ -1,0 +1,25 @@
+# This file is under MIT license. The license file can be obtained in the root directory of this module.
+
+import pytest
+from dmx.sacn.messages.root_layer import RootLayer
+from dmx.sacn.sending.sender_socket_base import SenderSocketBase, SenderSocketListener
+
+
+def test_abstract_sender_socket_listener():
+    listener = SenderSocketListener()
+    with pytest.raises(NotImplementedError):
+        listener.on_periodic_callback(1.0)
+
+
+def test_abstract_sender_socket_base():
+    socket = SenderSocketBase(None)
+    with pytest.raises(NotImplementedError):
+        socket.start()
+    with pytest.raises(NotImplementedError):
+        socket.stop()
+    with pytest.raises(NotImplementedError):
+        socket.send_unicast(RootLayer(1, tuple(range(0, 16)), (0, 0, 0, 0)), 'test')
+    with pytest.raises(NotImplementedError):
+        socket.send_multicast(RootLayer(1, tuple(range(0, 16)), (0, 0, 0, 0)), 'test', 12)
+    with pytest.raises(NotImplementedError):
+        socket.send_broadcast(RootLayer(1, tuple(range(0, 16)), (0, 0, 0, 0)))

--- a/sacn/sending/sender_socket_test.py
+++ b/sacn/sending/sender_socket_test.py
@@ -1,0 +1,33 @@
+# This file is under MIT license. The license file can be obtained in the root directory of this module.
+
+import copy
+from dmx.sacn.messages.root_layer import RootLayer
+from dmx.sacn.sending.sender_socket_base import SenderSocketBase
+
+
+class SenderSocketTest(SenderSocketBase):
+    def __init__(self, listener=None):
+        super().__init__(listener)
+        self.start_called: bool = False
+        self.stop_called: bool = False
+        self.send_unicast_called: (RootLayer, str) = None
+        self.send_multicast_called: (RootLayer, str, int) = None
+        self.send_broadcast_called: RootLayer = None
+
+    def start(self) -> None:
+        self.start_called = True
+
+    def stop(self) -> None:
+        self.stop_called = True
+
+    def send_unicast(self, data: RootLayer, destination: str) -> None:
+        self.send_unicast_called = (copy.deepcopy(data), copy.deepcopy(destination))
+
+    def send_multicast(self, data: RootLayer, destination: str, ttl: int) -> None:
+        self.send_multicast_called = (copy.deepcopy(data), copy.deepcopy(destination), ttl)
+
+    def send_broadcast(self, data: RootLayer) -> None:
+        self.send_broadcast_called = copy.deepcopy(data)
+
+    def call_on_periodic_callback(self, time: float) -> None:
+        self._listener.on_periodic_callback(time)

--- a/sacn/sending/sender_socket_udp.py
+++ b/sacn/sending/sender_socket_udp.py
@@ -1,0 +1,96 @@
+# This file is under MIT license. The license file can be obtained in the root directory of this module.
+
+import socket
+import time
+import threading
+
+from dmx.sacn.messages.root_layer import RootLayer
+from dmx.sacn.sending.sender_socket_base import SenderSocketBase, SenderSocketListener, DEFAULT_PORT
+
+THREAD_NAME = 'sACN sending/sender thread'
+
+
+class SenderSocketUDP(SenderSocketBase):
+    """
+    Implements a sender socket with a UDP socket of the OS.
+    """
+
+    def __init__(self, listener: SenderSocketListener, bind_address: str, bind_port: int, fps: int):
+        super().__init__(listener=listener)
+
+        self._bind_address: str = bind_address
+        self._bind_port: int = bind_port
+        self._enabled_flag: bool = True
+        self.fps: int = fps
+
+        # initialize the UDP socket
+        self._socket: socket.socket = socket.socket(socket.AF_INET,  # Internet
+                                                    socket.SOCK_DGRAM)  # UDP
+        try:
+            self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        except socket.error:  # Not all systems support multiple sockets on the same port and interface
+            pass
+
+        try:
+            self._socket.bind((self._bind_address, self._bind_port))
+            self._logger.info(f'Bind sender thread to IP:{self._bind_address} Port:{self._bind_port}')
+        except socket.error:
+            self._logger.exception(f'Could not bind to IP:{self._bind_address} Port:{self._bind_port}')
+            raise
+
+    def start(self):
+        # initialize thread infos
+        self._thread = threading.Thread(
+            target=self.send_loop,
+            name=THREAD_NAME
+        )
+        # self._thread.setDaemon(True)  # TODO: might be beneficial to use a daemon thread
+        self._thread.start()
+
+    def send_loop(self) -> None:
+        self._logger.info(f'Started {THREAD_NAME}')
+        self._enabled_flag = True
+        while self._enabled_flag:
+            time_stamp = time.time()
+            self._listener.on_periodic_callback(time_stamp)
+            time_to_sleep = (1 / self.fps) - (time.time() - time_stamp)
+            if time_to_sleep < 0:  # if time_to_sleep is negative (because the loop has too much work to do) set it to 0
+                time_to_sleep = 0
+            time.sleep(time_to_sleep)
+            # this sleeps nearly exactly so long that the loop is called every 1/fps seconds
+
+        self._logger.info(f'Stopped {THREAD_NAME}')
+
+    def stop(self) -> None:
+        """
+        Stops a running thread and closes the underlying socket. If no thread was started, nothing happens.
+        Do not reuse the socket after calling stop once.
+        """
+        self._enabled_flag = False
+        # wait for the thread to finish
+        try:
+            self._thread.join()
+            # stop the socket, after the loop terminated
+            self._socket.close()
+        except AttributeError:
+            pass
+
+    def send_unicast(self, data: RootLayer, destination: str) -> None:
+        self.send_packet(data.getBytes(), destination)
+
+    def send_multicast(self, data: RootLayer, destination: str, ttl: int) -> None:
+        # make socket multicast-aware: (set TTL)
+        self._socket.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, ttl)
+        self.send_packet(data.getBytes(), destination)
+
+    def send_broadcast(self, data: RootLayer) -> None:
+        # hint: on windows a bind address must be set, to use broadcast
+        self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        self.send_packet(data.getBytes(), destination='<broadcast>')
+
+    def send_packet(self, data: bytearray, destination: str) -> None:
+        data_raw = bytearray(data)
+        try:
+            self._socket.sendto(data_raw, (destination, DEFAULT_PORT))
+        except OSError as e:
+            self._logger.warning('Failed to send packet', exc_info=e)

--- a/universe.py
+++ b/universe.py
@@ -33,7 +33,7 @@ class DMX_Universe(PropertyGroup):
         name = "Input",
         description = "Input source of the universe",
         default = "BLENDERDMX",
-        items = (("BLENDERDMX", "BlenderDMX", "Set DMX buffer from the Programmer"), ("ARTNET", "ArtNet", "Read DMX buffer from ArtNet"))
+        items = (("BLENDERDMX", "BlenderDMX", "Set DMX buffer from the Programmer"), ("ARTNET", "ArtNet", "Read DMX buffer from ArtNet"), ("sACN", "sACN", "Read DMX buffer from sACN"))
     )
 
     input_settings: StringProperty (


### PR DESCRIPTION
This adds sACN support. The receiver is vendored from https://github.com/Hundemeier/sacn

The advantage of sACN as opposed to Art-Net is multicasting - there is no need to set up IP addresses. sACN also indexes universes from "1", which is nicer, but always causes issues in places where there already is Art-Net support present (as Art-Net starts from "0") :) . So... all sANCsettings are using the "start from 1" convention (you have to enable two universes, because sACN needs universe "1")... except, devices for some reason use `return DMX_Data._universes[universe-1]`, i am not clear why and how :) EDIT: i tested on Windows and things seem to be a bit different there.. i think this is where the difference comes from as per my previous comment... it seems that the universe is up by one on Windows. Anyways, it works, one has to play with the number of universes a bit. Unfortunately, Art-Net with the 0 based indexing made it confusing for people.

I renamed the panel name from Art-Net to Ethernet, but kept the signalling logic of `dmx.artnet_status` the same. Upon disabling sACN, the thread seems to close up correctly, unlike the Art-Net, which seems to cause some hangs.

This also depends on the https://github.com/hugoaboud/blenderDMX/pull/19 PR, so i can rebase this one up after merging the https://github.com/hugoaboud/blenderDMX/pull/19.

![image](https://user-images.githubusercontent.com/3680926/211194800-bcf5ad27-0586-40ec-9cf2-e778be00b6e4.png)
